### PR TITLE
travis: verify number of passed tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ language: python
 
 .mixtures:  # is not used by Travis CI, but helps avoid duplication
   - &if-cron-or-manual-run-or-tagged
-    if: type IN (cron, api) OR tag IS present
+    # if travis keyword is in commit message, we do run all jobs
+    if: type IN (cron, api) OR tag IS present OR commit_message =~ /travis/
   - &py-27
     python: "2.7"
   - &py-36
@@ -97,77 +98,91 @@ jobs:
 
     - <<: *py-38
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible29-unit
       name: unit tests, Ansible 2.9, Python 3.8
 
     - <<: *py-38
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible28-unit
       name: unit tests, Ansible 2.8, Python 3.8
 
     - <<: *py-37
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible29-unit
       name: unit tests, Ansible 2.9, Python 3.7
 
     - <<: *py-37
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible28-unit
       name: unit tests, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible27-unit
       name: unit tests, Ansible 2.7, Python 3.7
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible29-unit
       name: unit tests, Ansible 2.9, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible28-unit
       name: unit tests, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible27-unit
       name: unit tests, Ansible 2.7, Python 3.6
 
     - <<: *py-27
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible29-unit
       name: unit tests, Ansible 2.9, Python 2.7
 
     - <<: *py-27
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible28-unit
       name: unit tests, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansible27-unit
       name: unit tests, Ansible 2.7, Python 2.7
 
     - <<: *py-37
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansible29-functional
       name: functional tests shard 1, Ansible 2.9, Python 3.7
 
     - <<: *py-37
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansible29-functional
       name: functional tests shard 2, Ansible 2.9, Python 3.7
 
     - <<: *py-37
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansible28-functional
       name: functional tests shard 1, Ansible 2.8, Python 3.7
 
@@ -180,12 +195,14 @@ jobs:
     - <<: *py-37
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=29
         - TOXENV=ansible27-functional
       name: functional tests shard 1, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=26
         - TOXENV=ansible27-functional
       name: functional tests shard 2, Ansible 2.7, Python 3.7
 
@@ -193,6 +210,7 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=29
         - TOXENV=ansible27-functional
       name: functional tests shard 1, Ansible 2.7, Python 3.6
 
@@ -200,6 +218,7 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=26
         - TOXENV=ansible27-functional
       name: functional tests shard 2, Ansible 2.7, Python 3.6
 
@@ -207,6 +226,7 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansible28-functional
       name: functional tests shard 1, Ansible 2.8, Python 3.6
 
@@ -214,6 +234,7 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansible28-functional
       name: functional tests shard 2, Ansible 2.8, Python 3.6
 
@@ -221,6 +242,7 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=29
         - TOXENV=ansible27-functional
       name: functional tests shard 1, Ansible 2.7, Python 3.6
 
@@ -228,42 +250,49 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=26
         - TOXENV=ansible27-functional
       name: functional tests shard 2, Ansible 2.7, Python 3.6
 
     - <<: *py-27
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansible29-functional
       name: functional tests shard 1, Ansible 2.9, Python 2.7
 
     - <<: *py-27
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansible29-functional
       name: functional tests shard 2, Ansible 2.9, Python 2.7
 
     - <<: *py-27
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansible28-functional
       name: functional tests shard 1, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansible28-functional
       name: functional tests shard 2, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=29
         - TOXENV=ansible27-functional
       name: functional tests shard 1, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=26
         - TOXENV=ansible27-functional
       name: functional tests shard 2, Ansible 2.7, Python 2.7
 
@@ -273,46 +302,55 @@ jobs:
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansibledevel-unit
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansibledevel-functional
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansibledevel-functional
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - TOXENV=ansibledevel-unit
+        - PYTEST_REQPASS=560
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansibledevel-functional
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansibledevel-functional
 
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:
+        - PYTEST_REQPASS=560
         - TOXENV=ansibledevel-unit
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansibledevel-functional
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - PYTEST_REQPASS=37
         - TOXENV=ansibledevel-functional
 
     - &deploy-job

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
 import os
 import pytest
+import sys
 
 pytest_plugins = ['helpers_namespace']
 
@@ -14,3 +16,22 @@ def environ():
     # adds extra environment variables that may be needed during testing
     if not os.environ.get('TEST_BASE_IMAGE', ""):
         os.environ['TEST_BASE_IMAGE'] = 'docker.io/pycontribs/centos:7'
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    yield
+    req_passed = int(os.environ.get('PYTEST_REQPASS', '0'))
+    if req_passed:
+        passed = 0
+        for x in terminalreporter.stats.get('passed', []):
+            if x.when == 'call' and x.outcome == 'passed':
+                passed += 1
+        if passed != req_passed:
+            print(
+                'ERROR: {} passed test but expected number was {}.'.format(
+                    passed, req_passed
+                ),
+                file=sys.stderr,
+            )
+            sys.exit(127)

--- a/setup.cfg
+++ b/setup.cfg
@@ -116,6 +116,7 @@ test =
     pytest-helpers-namespace>=2019.1.8, < 2020
     pytest-mock>=1.10.4, < 2
     pytest-verbose-parametrize>=1.7.0, < 2
+    pytest-sugar>=0.9.2, < 1
     pytest-xdist>=1.29.0, < 2
     shade>=1.31.0, < 2
 


### PR DESCRIPTION
Introduces a PYTEST_MINPASS option that makes pytest fail a test suite
if the minimum number of tests was not run.

By defining minimum number of expected tests for each CI job, we can
now prevent accidents where some tests are not run due to other
changes made to the test environment.

We had at least one case where --delegated prevented execution of
some tests in CI and we ended up with more broken tests.
