### PR TITLE
Truncate long docker instance names

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -142,7 +142,7 @@
 
     - name: Create molecule instance(s)
       docker_container:
-        name: "{{ item.name }}"
+        name: "{{ item.name | truncate(50, True, '', 0) }}"
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"


### PR DESCRIPTION
[Truncates](https://jinja.palletsprojects.com/en/2.10.x/templates/#truncate) the docker instance name to:
- truncate after `50` characters.
- `True` to cut text
- `''` to indicate the text was truncated. (no character are place.)
- `0` tolerance.

Using these options, the `item.name` is truncated at 50 characters exactly.

Partial-Fixes: #2462