### PR TITLE
Speedup testing by using smaller images

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,4 +13,8 @@ def environ():
 
     # adds extra environment variables that may be needed during testing
     if not os.environ.get('TEST_BASE_IMAGE', ""):
-        os.environ['TEST_BASE_IMAGE'] = 'docker.io/pycontribs/centos:7'
+        os.environ['TEST_BASE_IMAGE'] = 'docker.io/pycontribs/alpine:latest'
+    # size of image used for testing is key for speed, especially on CI,
+    # alpine is <30MB while centos ones are >130MB. The only requirement we
+    # have is to have an image that can be managed by ansible without extra
+    # work.

--- a/molecule/test/scenarios/driver/podman/molecule/ansible-verifier/molecule.yml
+++ b/molecule/test/scenarios/driver/podman/molecule/ansible-verifier/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: docker.io/pycontribs/alpine:latest
     registry:
       url: docker.io
     networks:

--- a/molecule/test/scenarios/driver/podman/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/podman/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: docker.io/pycontribs/alpine:latest
     registry:
       url: docker.io
     buildargs:

--- a/molecule/test/scenarios/driver/podman/molecule/multi-node/molecule.yml
+++ b/molecule/test/scenarios/driver/podman/molecule/multi-node/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../../resources/.yamllint
 platforms:
   - name: instance-1
-    image: centos:latest
+    image: docker.io/pycontribs/alpine:latest
     registry:
       url: docker.io
     groups:
@@ -18,7 +18,7 @@ platforms:
     buildargs:
       testarg: this_is_a_test
   - name: instance-2
-    image: centos:latest
+    image: docker.io/pycontribs/alpine:latest
     registry:
       url: docker.io
     groups:


### PR DESCRIPTION
Instea of using a `centos:7` image for running tests, we use an `alpine` one which is 4x smaller. This should bring measurable speed improvements on Travis CI which does not cache images.
