### PR TITLE
Add the ability to configure docker_networks


### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -89,13 +89,16 @@
 
     - name: Create docker network(s)
       docker_network:
-        name: "{{ item }}"
+        name: "{{ item.name }}"
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
         state: present
+        appends: "{{ item.appends | default(omit) }}"
+        enable_ipv6: "{{ item.enable_ipv6 | default(omit) }}"
+        ipam_config: "{{ item.ipam_config | default(omit) }}"
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
       loop_control:
         label: "{{ item }}"

--- a/molecule/provisioner/ansible/playbooks/docker/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/destroy.yml
@@ -34,7 +34,7 @@
 
     - name: Delete docker network(s)
       docker_network:
-        name: "{{ item }}"
+        name: "{{ item.name }}"
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"

--- a/molecule/provisioner/ansible/plugins/filter/molecule_core.py
+++ b/molecule/provisioner/ansible/plugins/filter/molecule_core.py
@@ -55,14 +55,18 @@ def header(content):
 
 
 def get_docker_networks(data):
-    network_list = []
+    networks = {}
     for platform in data:
-        if "networks" in platform:
+        if "docker_networks" in platform:
+            for network in platform['docker_networks']:
+                if network['name'] not in networks:
+                    networks[network['name']] = network
+        elif "networks" in platform:
             for network in platform['networks']:
                 if "name" in network:
-                    name = network['name']
-                    network_list.append(name)
-    return network_list
+                    if network['name'] not in networks:
+                        networks[network['name']] = {'name': name}
+    return list(networks.values())
 
 
 class FilterModule(object):

--- a/molecule/test/resources/playbooks/docker/create.yml
+++ b/molecule/test/resources/playbooks/docker/create.yml
@@ -72,13 +72,16 @@
 
     - name: Create docker network(s)
       docker_network:
-        name: "{{ item }}"
+        name: "{{ item.name }}"
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
         state: present
+        appends: "{{ item.appends | default(omit) }}"
+        enable_ipv6: "{{ item.enable_ipv6 | default(omit) }}"
+        ipam_config: "{{ item.ipam_config | default(omit) }}"
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
 
     - name: Determine the CMD directives

--- a/molecule/test/resources/playbooks/docker/destroy.yml
+++ b/molecule/test/resources/playbooks/docker/destroy.yml
@@ -32,7 +32,7 @@
 
     - name: Delete docker network(s)
       docker_network:
-        name: "{{ item }}"
+        name: "{{ item.name }}"
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"


### PR DESCRIPTION


Currently, on creation, the docker_network module only receives the
name of the network to create. It is therefore impossible to configure
advanced details like IPAM.

Without this patch, a molecule.yaml containing multiple platforms with
multiple networks with static IPs will basically fail, as it is not possible
to determine the network ranges, because we don't pass IPAM details at the
network creation time.

It is a problem, as everyone having docker_networks should basically have
their own create/destroy playbooks to overcome this.

This fixes the behaviour by adding a new key into platforms,
named docker_networks. A new key was necessary because "networks" is used
inside the docker_container creation, which takes different arguments
than docker_network.

