### PR TITLE
Support the podman --systemd option (instead of --privileged)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Changelog
 * Use pluggy to load plugins
 * Windows & Linux EC2 instances can be tested simultaneously
 * Windows EC2 instances can be provisioned using the automatically-generated password
+* Support the Podman ``--systemd=True`` option for running systemd in
+  containers without ``--privileged``.
 
 2.22
 ====

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -116,7 +116,7 @@ class Docker(Driver):
 
     When attempting to utilize a container image with `systemd`_ as your init
     system inside the container to simulate a real machine, make sure to set
-    the ``privileged``, ``volumes``, ``command``, and ``environment``
+    the ``privileged`` or ``systemd``, ``volumes``, ``command``, and ``environment``
     values. An example using the ``centos:7`` image is below:
 
     .. note:: Do note that running containers in privileged mode is considerably
@@ -145,6 +145,20 @@ class Docker(Driver):
     .. code-block:: bash
 
         $ pip install molecule[docker]
+
+    Alternatively, specify ``systemd: True`` to use the Podman ``--systemd``
+    value and run ``setsebool -P container_manage_cgroup true``
+    to allow containers to configure cgroups
+    if SELinux is enabled. For example:
+
+    .. code-block:: yaml
+
+        platforms:
+        - name: instance
+          image: centos:7
+          systemd: True
+          command: "/usr/sbin/init"
+          tty: True
 
     When pulling from a private registry, it is the user's discretion to decide
     whether to use hard-code strings or environment variables for passing

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -60,6 +60,7 @@ class Podman(Driver):
             tty: True|False
             pid_mode: host
             privileged: True|False
+            systemd: False|True
             security_opts:
               - seccomp=unconfined
             volumes:

--- a/molecule/provisioner/ansible/playbooks/podman/create.yml
+++ b/molecule/provisioner/ansible/playbooks/podman/create.yml
@@ -85,6 +85,7 @@
         --name "{{ item.name }}"
         {% if item.pid_mode is defined %}--pid={{ item.pid_mode }}{% endif %}
         {% if item.privileged is defined %}--privileged={{ item.privileged }}{% endif %}
+        {% if item.systemd is defined %}--systemd={{ item.systemd }}{% endif %}
         {% if item.security_opts is defined %}{% for i in item.security_opts %}--security-opt {{ i }} {% endfor %}{% endif %}
         {% if item.volumes is defined %}{% for i in item.volumes %}--volume {{ i }} {% endfor %}{% endif %}
         {% if item.tmpfs is defined %}{% for i in item.tmpfs %}--tmpfs={{ i }} {% endfor %}{% endif %}


### PR DESCRIPTION
Support the Podman ``--systemd=True`` option for running systemd in containers without ``--privileged``.

This has apparently been possible since https://developers.redhat.com/blog/2019/04/24/how-to-run-systemd-in-a-container/

In ``role/molecule/default/molecule.yml``:

```yaml
        driver:
          name: podman
        platforms:
        - name: instance
          image: centos:7
          systemd: True
          command: "/usr/sbin/init"
          tty: True
        - name: instance 2
          image: fedora:31
          systemd: True
          command: "/sbin/init"
```

- [x] Please include details of what it is, how to use it, how it's been tested
- [x] Please include an entry in the CHANGELOG.md if the change will impact users.

#### PR Type

- Feature Pull Request
