### PR TITLE
docker: networks_cli_compatible default to true

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -139,6 +139,7 @@
         ulimits: "{{ item.ulimits | default(omit) }}"
         networks: "{{ item.networks | default(omit) }}"
         network_mode: "{{ item.network_mode | default(omit) }}"
+        networks_cli_compatible: "{{ item.networks_cli_compatible | default(true) }}"
         purge_networks: "{{ item.purge_networks | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"
         etc_hosts: "{{ item.etc_hosts | default(omit) }}"

--- a/molecule/test/resources/playbooks/delegated/create/docker.yml
+++ b/molecule/test/resources/playbooks/delegated/create/docker.yml
@@ -10,3 +10,4 @@
     ulimits: "{{ item.ulimits | default(omit) }}"
     networks: "{{ item.networks | default(omit) }}"
     dns_servers: "{{ item.dns_servers | default(omit) }}"
+    networks_cli_compatible: "{{ item.networks_cli_compatible | default(true) }}"

--- a/molecule/test/resources/playbooks/docker/create.yml
+++ b/molecule/test/resources/playbooks/docker/create.yml
@@ -116,6 +116,7 @@
         published_ports: "{{ item.published_ports | default(omit) }}"
         ulimits: "{{ item.ulimits | default(omit) }}"
         networks: "{{ item.networks | default(omit) }}"
+        networks_cli_compatible: "{{ item.networks_cli_compatible | default(true) }}"
         network_mode: "{{ item.network_mode | default(omit) }}"
         purge_networks: "{{ item.purge_networks | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"


### PR DESCRIPTION
Avoids below deprecation warning from code inside molecule by setting
the networks_cli_compatible to true which is also future proof, unless
user mentions another value.

> [DEPRECATION WARNING]: Please note that docker_container handles networks
> slightly different than docker CLI. If you specify networks, the default
> network will still be attached as the first network. (You can specify
> purge_networks to remove all networks not explicitly listed.) This behavior
> will change in Ansible 2.12. You can change the behavior now by setting the new
>  `networks_cli_compatible` option to `yes`, and remove this warning by setting
> it to `no`. This feature will be removed in version 2.12. Deprecation warnings
> can be disabled by setting deprecation_warnings=False in ansible.cfg.
> 
