### PR TITLE
Reduce the duration of functional testing

### DIFF
--- a/molecule/test/scenarios/.flake8
+++ b/molecule/test/scenarios/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+# TODO(ssbarnea): Remove this file once we make entire codebase pydocstyle compliant
+# Prevents tests failure when run on systems that have pytest-docstrings already installed, the other settings are copied from root version.
+
+# E203: https://github.com/python/black/issues/315
+ignore = D,E741,W503,W504,H,E501,E203
+# 88 is official black default:
+max-line-length = 88

--- a/molecule/test/scenarios/driver/docker/molecule/ansible-verifier/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/ansible-verifier/molecule.yml
@@ -13,8 +13,7 @@ platforms:
     networks:
       - name: foo
       - name: bar
-    buildargs:
-      testarg: this_is_a_test
+    pre_build_image: true
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/test/scenarios/driver/docker/molecule/ansible-verifier/verify.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/ansible-verifier/verify.yml
@@ -31,7 +31,3 @@
         - instance_file.stat.pw_name == 'root'
         - instance_file.stat.gr_name == 'root'
         - instance_file.stat.mode == "0644"
-
-  - name: Assert that the envarg envvar was set
-    assert:
-      that: ansible_env.envarg == 'this_is_a_test'

--- a/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
@@ -13,8 +13,7 @@ platforms:
     networks:
       - name: foo
       - name: bar
-    buildargs:
-      testarg: this_is_a_test
+    pre_build_image: true
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/driver/docker/molecule/default/tests/test_default.py
+++ b/molecule/test/scenarios/driver/docker/molecule/default/tests/test_default.py
@@ -28,8 +28,3 @@ def test_etc_molecule_ansible_hostname_file(host):
     assert f.user == 'root'
     assert f.group == 'root'
     assert f.mode == 0o644
-
-
-def test_buildarg_env_var(host):
-    cmd_out = host.run("echo $envarg")
-    assert cmd_out.stdout.strip() == 'this_is_a_test'

--- a/molecule/test/scenarios/driver/docker/molecule/multi-node/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/multi-node/molecule.yml
@@ -10,18 +10,16 @@ lint:
 platforms:
   - name: instance-1
     image: ${TEST_BASE_IMAGE}
+    pre_build_image: true
     groups:
       - foo
       - bar
-    buildargs:
-      testarg: this_is_a_test
   - name: instance-2
     image: ${TEST_BASE_IMAGE}
     groups:
       - foo
       - baz
-    buildargs:
-      testarg: this_is_a_test
+    pre_build_image: true
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/driver/docker/molecule/multi-node/playbook.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/multi-node/playbook.yml
@@ -5,24 +5,3 @@
   become: true
   roles:
     - molecule
-
-- name: Converge
-  hosts: bar
-  gather_facts: false
-  become: true
-  roles:
-    - molecule
-
-- name: Converge
-  hosts: foo
-  gather_facts: false
-  become: true
-  roles:
-    - molecule
-
-- name: Converge
-  hosts: baz
-  gather_facts: false
-  become: true
-  roles:
-    - molecule

--- a/molecule/test/scenarios/driver/docker/molecule/multi-node/requirements.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/multi-node/requirements.yml
@@ -1,4 +1,0 @@
----
-- name: timezone
-  src: yatesr.timezone
-  version: 1.1.0


### PR DESCRIPTION
The longest-running test was ~350s and now ~130s.

Tested locally via:
```
pytest -sx -k "test_command_test[driver/docker-docker-multi-node]"
```