### PR TITLE
Enable flake8-docstrings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,7 @@
 exclude = .venv/,.tox/,dist/,build/,.eggs/
 format = pylint
 # E203: https://github.com/python/black/issues/315
-ignore = E741,W503,W504,H,E501,E203,D100,D101,D102,D103,D104,D105,D107,D400,D401
+ignore = E741,W503,W504,H,E501,E203,D100,D101,D102,D103,D104,D105,D107,D401
 # TODO(ssbarnea): remove temporary skips one by one:
 # [D100] Missing docstring in public module
 # [D101] Missing docstring in public class
@@ -12,7 +12,6 @@ ignore = E741,W503,W504,H,E501,E203,D100,D101,D102,D103,D104,D105,D107,D400,D401
 # [D104] Missing docstring in public package
 # [D105] Missing docstring in magic method
 # [D107] Missing docstring in __init__
-# [D400] First line should end with a period
 # [D401] First line should be in imperative mood
 # 88 is official black default:
 max-line-length = 88

--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,7 @@
 exclude = .venv/,.tox/,dist/,build/,.eggs/
 format = pylint
 # E203: https://github.com/python/black/issues/315
-ignore = E741,W503,W504,H,E501,E203,D100,D101,D102,D103,D104,D105,D107,D205,D210,D400,D401
+ignore = E741,W503,W504,H,E501,E203,D100,D101,D102,D103,D104,D105,D107,D400,D401
 # TODO(ssbarnea): remove temporary skips one by one:
 # [D100] Missing docstring in public module
 # [D101] Missing docstring in public class
@@ -12,9 +12,6 @@ ignore = E741,W503,W504,H,E501,E203,D100,D101,D102,D103,D104,D105,D107,D205,D210
 # [D104] Missing docstring in public package
 # [D105] Missing docstring in magic method
 # [D107] Missing docstring in __init__
-# [D202] No blank lines allowed after function docstring
-# [D205] 1 blank line required between summary line and description
-# [D210] No whitespaces allowed surrounding docstring text
 # [D400] First line should end with a period
 # [D401] First line should be in imperative mood
 # 88 is official black default:

--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,19 @@
 exclude = .venv/,.tox/,dist/,build/,.eggs/
 format = pylint
 # E203: https://github.com/python/black/issues/315
-ignore = E741,W503,W504,H,E501,E203
+ignore = E741,W503,W504,H,E501,E203,D100,D101,D102,D103,D104,D105,D107,D205,D210,D400,D401
+# TODO(ssbarnea): remove temporary skips one by one:
+# [D100] Missing docstring in public module
+# [D101] Missing docstring in public class
+# [D102] Missing docstring in public method
+# [D103] Missing docstring in public function
+# [D104] Missing docstring in public package
+# [D105] Missing docstring in magic method
+# [D107] Missing docstring in __init__
+# [D202] No blank lines allowed after function docstring
+# [D205] 1 blank line required between summary line and description
+# [D210] No whitespaces allowed surrounding docstring text
+# [D400] First line should end with a period
+# [D401] First line should be in imperative mood
 # 88 is official black default:
 max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
         additional_dependencies:
           - flake8-absolute-import
           - flake8-black>=0.1.1
+          - flake8-docstrings>=1.5.0
           - flake8-mypy
         language_version: python3
   - repo: https://github.com/adrienverge/yamllint.git

--- a/molecule/api.py
+++ b/molecule/api.py
@@ -10,7 +10,9 @@ LOG = logger.get_logger(__name__)
 
 
 class UserListMap(UserList):
-    """A list where you can also access elements by their name using:
+    """A list where you can also access elements by their name
+
+    Example:
     foo['boo']
     foo.boo
     """

--- a/molecule/api.py
+++ b/molecule/api.py
@@ -10,7 +10,7 @@ LOG = logger.get_logger(__name__)
 
 
 class UserListMap(UserList):
-    """A list where you can also access elements by their name
+    """A list where you can also access elements by their name.
 
     Example:
     foo['boo']

--- a/molecule/api.py
+++ b/molecule/api.py
@@ -10,9 +10,9 @@ LOG = logger.get_logger(__name__)
 
 
 class UserListMap(UserList):
-    """ A list where you can also access elements by their name using:
-      foo['boo']
-      foo.boo
+    """A list where you can also access elements by their name using:
+    foo['boo']
+    foo.boo
     """
 
     def __getitem__(self, i):

--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -38,9 +38,7 @@ MOLECULE_DEFAULT_SCENARIO_NAME = 'default'
 
 @six.add_metaclass(abc.ABCMeta)
 class Base(object):
-    """
-    An abstract base class used to define the command interface.
-    """
+    """An abstract base class used to define the command interface."""
 
     def __init__(self, c):
         """
@@ -135,9 +133,7 @@ def execute_scenario(scenario):
 
     :param scenario: The scenario to execute.
     :returns: None
-
     """
-
     for action in scenario.sequence:
         execute_subcommand(scenario.config, action)
 

--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -149,7 +149,7 @@ def execute_scenario(scenario):
 
 def get_configs(args, command_args, ansible_args=()):
     """
-    Glob the current directory for Molecule config files, instantiate config
+    Glob the current directory for Molecule config files, instantiate config \
     objects, and returns a list.
 
     :param args: A dict of options, arguments and commands from the CLI.

--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -71,7 +71,7 @@ class Check(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule check` and
+        Execute the actions necessary to perform a `molecule check` and \
         returns None.
 
         :return: None
@@ -96,10 +96,8 @@ class Check(base.Base):
     help='Enable or disable parallel mode. Default is disabled.',
 )
 def check(ctx, scenario_name, parallel):  # pragma: no cover
-    """
-    Use the provisioner to perform a Dry-Run (destroy, dependency, create,
-    prepare, converge).
-    """
+    """Use the provisioner to perform a Dry-Run (destroy, dependency, create, \
+    prepare, converge)."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'parallel': parallel, 'subcommand': subcommand}

--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -31,6 +31,8 @@ MOLECULE_PARALLEL = os.environ.get('MOLECULE_PARALLEL', False)
 
 class Check(base.Base):
     """
+    Check Command Class.
+
     .. program:: molecule check
 
     .. option:: molecule check

--- a/molecule/command/cleanup.py
+++ b/molecule/command/cleanup.py
@@ -28,6 +28,8 @@ LOG = logger.get_logger(__name__)
 
 class Cleanup(base.Base):
     """
+    Cleanup Command Class
+
     This action has cleanup and is not enabled by default.
     See the provisioner's documentation for further details.
 
@@ -65,7 +67,7 @@ class Cleanup(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to cleanup the instances and returns
+        Execute the actions necessary to cleanup the instances and returns \
         None.
 
         :return: None
@@ -91,10 +93,8 @@ class Cleanup(base.Base):
     ),
 )
 def cleanup(ctx, scenario_name):  # pragma: no cover
-    """
-    Use the provisioner to cleanup any changes made to external systems during
-    the stages of testing.
-    """
+    """Use the provisioner to cleanup any changes made to external systems during \
+    the stages of testing."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/command/cleanup.py
+++ b/molecule/command/cleanup.py
@@ -28,7 +28,7 @@ LOG = logger.get_logger(__name__)
 
 class Cleanup(base.Base):
     """
-    Cleanup Command Class
+    Cleanup Command Class.
 
     This action has cleanup and is not enabled by default.
     See the provisioner's documentation for further details.

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -71,7 +71,7 @@ class Converge(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule converge` and
+        Execute the actions necessary to perform a `molecule converge` and \
         returns None.
 
         :return: None
@@ -93,10 +93,7 @@ class Converge(base.Base):
 )
 @click.argument('ansible_args', nargs=-1, type=click.UNPROCESSED)
 def converge(ctx, scenario_name, ansible_args):  # pragma: no cover
-    """
-    Use the provisioner to configure instances (dependency, create, prepare
-    converge).
-    """
+    """Use the provisioner to configure instances (dependency, create, prepare converge)."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -28,6 +28,8 @@ LOG = logger.get_logger(__name__)
 
 class Converge(base.Base):
     """
+    Converge Command Class.
+
     .. program:: molecule converge
 
     .. option:: molecule converge

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -97,7 +97,6 @@ def converge(ctx, scenario_name, ansible_args):  # pragma: no cover
     Use the provisioner to configure instances (dependency, create, prepare
     converge).
     """
-
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -29,6 +29,8 @@ LOG = logger.get_logger(__name__)
 
 class Create(base.Base):
     """
+    Create Command Class.
+
     .. program:: molecule create
 
     .. option:: molecule create

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -69,7 +69,7 @@ class Create(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule create` and
+        Execute the actions necessary to perform a `molecule create` and \
         returns None.
 
         :return: None
@@ -109,7 +109,7 @@ class Create(base.Base):
     help='Name of driver to use. (docker)',
 )
 def create(ctx, scenario_name, driver_name):  # pragma: no cover
-    """ Use the provisioner to start the instances. """
+    """Use the provisioner to start the instances."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand, 'driver_name': driver_name}

--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -62,7 +62,7 @@ class Dependency(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule dependency` and
+        Execute the actions necessary to perform a `molecule dependency` and \
         returns None.
 
         :return: None
@@ -82,7 +82,7 @@ class Dependency(base.Base):
     ),
 )
 def dependency(ctx, scenario_name):  # pragma: no cover
-    """ Manage the role's dependencies. """
+    """Manage the role's dependencies."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -28,6 +28,8 @@ LOG = logger.get_logger(__name__)
 
 class Dependency(base.Base):
     """
+    Dependency Command Class.
+
     .. program:: molecule dependency
 
     .. option:: molecule dependency

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -84,7 +84,7 @@ class Destroy(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule destroy` and
+        Execute the actions necessary to perform a `molecule destroy` and \
         returns None.
 
         :return: None
@@ -133,7 +133,7 @@ class Destroy(base.Base):
     help='Enable or disable parallel mode. Default is disabled.',
 )
 def destroy(ctx, scenario_name, driver_name, __all, parallel):  # pragma: no cover
-    """ Use the provisioner to destroy the instances. """
+    """Use the provisioner to destroy the instances."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -32,6 +32,8 @@ MOLECULE_PARALLEL = os.environ.get('MOLECULE_PARALLEL', False)
 
 class Destroy(base.Base):
     """
+    Destroy Command Class.
+
     .. program:: molecule destroy
 
     .. option:: molecule destroy

--- a/molecule/command/drivers.py
+++ b/molecule/command/drivers.py
@@ -39,7 +39,7 @@ LOG = logger.get_logger(__name__)
     help='Change output format. (simple)',
 )
 def drivers(ctx, format):  # pragma: no cover
-    """ Lists drivers. """
+    """Lists drivers."""
     drivers = [[x] for x in api.drivers()]
 
     headers = ['name']

--- a/molecule/command/drivers.py
+++ b/molecule/command/drivers.py
@@ -40,7 +40,6 @@ LOG = logger.get_logger(__name__)
 )
 def drivers(ctx, format):  # pragma: no cover
     """ Lists drivers. """
-
     drivers = [[x] for x in api.drivers()]
 
     headers = ['name']

--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -91,13 +91,11 @@ class Idempotence(base.Base):
             util.sysexit_with_message(msg)
 
     def _is_idempotent(self, output):
-        """
-        Parses the output of the provisioning for changed and returns a bool.
+        """Parses the output of the provisioning for changed and returns a bool.
 
         :param output: A string containing the output of the ansible run.
         :return: bool
         """
-
         # Remove blank lines to make regex matches easier
         output = re.sub(r'\n\s*\n*', '\n', output)
 

--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -31,7 +31,7 @@ LOG = logger.get_logger(__name__)
 
 class Idempotence(base.Base):
     """
-    Runs the converge step a second time. If no tasks will be marked as changed
+    Runs the converge step a second time. If no tasks will be marked as changed \
     the scenario will be considered idempotent.
 
     .. program:: molecule idempotence
@@ -68,7 +68,7 @@ class Idempotence(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule idempotence` and
+        Execute the actions necessary to perform a `molecule idempotence` and \
         returns None.
 
         :return: None
@@ -147,10 +147,8 @@ class Idempotence(base.Base):
     ),
 )
 def idempotence(ctx, scenario_name):  # pragma: no cover
-    """
-    Use the provisioner to configure the instances and parse the output to
-    determine idempotence.
-    """
+    """Use the provisioner to configure the instances and parse the output to \
+    determine idempotence."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/command/init/init.py
+++ b/molecule/command/init/init.py
@@ -29,7 +29,7 @@ LOG = logger.get_logger(__name__)
 
 @click.group()
 def init():  # pragma: no cover
-    """ Initialize a new role or scenario. """
+    """Initialize a new role or scenario."""
 
 
 init.add_command(role.role)

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -53,7 +53,7 @@ class Role(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule init role` and
+        Execute the actions necessary to perform a `molecule init role` and \
         returns None.
 
         :return: None
@@ -136,7 +136,7 @@ def role(
     role_name,
     verifier_name,
 ):  # pragma: no cover
-    """ Initialize a new role for use with Molecule. """
+    """Initialize a new role for use with Molecule."""
     command_args = {
         'dependency_name': dependency_name,
         'driver_name': driver_name,

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -58,7 +58,6 @@ class Role(base.Base):
 
         :return: None
         """
-
         role_name = self._command_args['role_name']
         role_directory = os.getcwd()
         msg = 'Initializing new role {}...'.format(role_name)

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -33,6 +33,8 @@ LOG = logger.get_logger(__name__)
 
 class Role(base.Base):
     """
+    Init Role Command Class.
+
     .. program:: molecule init role --role-name foo
 
     .. option:: molecule init role --role-name foo

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -60,7 +60,7 @@ class Scenario(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule init scenario` and
+        Execute the actions necessary to perform a `molecule init scenario` and \
         returns None.
 
         :return: None
@@ -212,7 +212,7 @@ def scenario(
     verifier_name,
     driver_template,
 ):  # pragma: no cover
-    """ Initialize a new scenario for use with Molecule. """
+    """Initialize a new scenario for use with Molecule."""
     command_args = {
         'dependency_name': dependency_name,
         'driver_name': driver_name,

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -34,6 +34,8 @@ LOG = logger.get_logger(__name__)
 
 class Scenario(base.Base):
     """
+    Scenario Class.
+
     .. program:: molecule init scenario --scenario-name bar --role-name foo
 
     .. option:: molecule init scenario --scenario-name bar --role-name foo

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -28,6 +28,8 @@ LOG = logger.get_logger(__name__)
 
 class Lint(base.Base):
     """
+    Lint Command Class.
+
     .. program:: molecule lint
 
     .. option:: molecule lint

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -62,7 +62,7 @@ class Lint(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule lint` and
+        Execute the actions necessary to perform a `molecule lint` and \
         returns None.
 
         :return: None
@@ -93,7 +93,7 @@ class Lint(base.Base):
     ),
 )
 def lint(ctx, scenario_name):  # pragma: no cover
-    """ Lint the role (dependency, lint). """
+    """Lint the role (dependency, lint)."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/command/list.py
+++ b/molecule/command/list.py
@@ -80,7 +80,7 @@ class List(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule list` and
+        Execute the actions necessary to perform a `molecule list` and \
         returns None.
 
         :return: None
@@ -99,7 +99,7 @@ class List(base.Base):
     help='Change output format. (simple)',
 )
 def list(ctx, scenario_name, format):  # pragma: no cover
-    """ Lists status of instances. """
+    """Lists status of instances."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand, 'format': format}

--- a/molecule/command/list.py
+++ b/molecule/command/list.py
@@ -34,6 +34,8 @@ LOG = logger.get_logger(__name__)
 
 class List(base.Base):
     """
+    List Command Class.
+
     .. program:: molecule list
 
     .. option:: molecule list

--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -38,6 +38,8 @@ LOG = logger.get_logger(__name__)
 
 class Login(base.Base):
     """
+    Login Command Class.
+
     .. program:: molecule login
 
     .. option:: molecule login

--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -88,7 +88,7 @@ class Login(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule login` and
+        Execute the actions necessary to perform a `molecule login` and \
         returns None.
 
         :return: None
@@ -172,7 +172,7 @@ class Login(base.Base):
     ),
 )
 def login(ctx, host, scenario_name):  # pragma: no cover
-    """ Log in to one instance. """
+    """Log in to one instance."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand, 'host': host}

--- a/molecule/command/matrix.py
+++ b/molecule/command/matrix.py
@@ -29,6 +29,8 @@ LOG = logger.get_logger(__name__)
 
 class Matrix(base.Base):
     """
+    Matric Command Class.
+
     .. program:: molecule matrix subcommand
 
     .. option:: molecule matrix subcommand

--- a/molecule/command/matrix.py
+++ b/molecule/command/matrix.py
@@ -69,10 +69,7 @@ class Matrix(base.Base):
 # subclasses have not all loaded at this point.
 @click.argument('subcommand', nargs=1, type=click.UNPROCESSED)
 def matrix(ctx, scenario_name, subcommand):  # pragma: no cover
-    """
-    List matrix of steps used to test instances.
-    """
-
+    """List matrix of steps used to test instances."""
     args = ctx.obj.get('args')
     command_args = {'subcommand': subcommand}
 

--- a/molecule/command/prepare.py
+++ b/molecule/command/prepare.py
@@ -29,8 +29,9 @@ LOG = logger.get_logger(__name__)
 
 class Prepare(base.Base):
     """
-    This action is for the purpose of preparing a molecule managed instance
+    This action is for the purpose of preparing a molecule managed instance \
     before the :py:class:`molecule.command.converge.Converge` action is run.
+
     Tasks contained within the ``prepare.yml`` playbook in the scenario
     directory will be run remotely on the managed instance. This action is run
     only once per test sequence.
@@ -81,7 +82,7 @@ class Prepare(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to prepare the instances and returns
+        Execute the actions necessary to prepare the instances and returns \
         None.
 
         :return: None
@@ -124,10 +125,7 @@ class Prepare(base.Base):
     help='Enable or disable force mode. Default is disabled.',
 )
 def prepare(ctx, scenario_name, driver_name, force):  # pragma: no cover
-    """
-    Use the provisioner to prepare the instances into a particular starting
-    state.
-    """
+    """Use the provisioner to prepare the instances into a particular starting state."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {

--- a/molecule/command/side_effect.py
+++ b/molecule/command/side_effect.py
@@ -28,8 +28,9 @@ LOG = logger.get_logger(__name__)
 
 class SideEffect(base.Base):
     """
-    This action has side effects and not enabled by default.   See the
-    provisioners documentation for further details.
+    This action has side effects and not enabled by default.
+
+    See the provisioners documentation for further details.
 
     .. program:: molecule side-effect
 
@@ -65,7 +66,7 @@ class SideEffect(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule side-effect` and
+        Execute the actions necessary to perform a `molecule side-effect` and \
         returns None.
 
         :return: None
@@ -90,7 +91,7 @@ class SideEffect(base.Base):
     ),
 )
 def side_effect(ctx, scenario_name):  # pragma: no cover
-    """ Use the provisioner to perform side-effects to the instances. """
+    """Use the provisioner to perform side-effects to the instances."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/command/syntax.py
+++ b/molecule/command/syntax.py
@@ -61,8 +61,7 @@ class Syntax(base.Base):
     """
 
     def execute(self):
-        """
-        Execute the actions necessary to perform a `molecule syntax` and
+        """Execute the actions necessary to perform a `molecule syntax` and \
         returns None.
 
         :return: None
@@ -82,7 +81,7 @@ class Syntax(base.Base):
     ),
 )
 def syntax(ctx, scenario_name):  # pragma: no cover
-    """ Use the provisioner to syntax check the role. """
+    """Use the provisioner to syntax check the role."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/command/syntax.py
+++ b/molecule/command/syntax.py
@@ -28,6 +28,8 @@ LOG = logger.get_logger(__name__)
 
 class Syntax(base.Base):
     """
+    Syntax Command Class.
+
     .. program:: molecule syntax
 
     .. option:: molecule syntax

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -129,7 +129,6 @@ def test(ctx, scenario_name, driver_name, __all, destroy, parallel):  # pragma: 
     Test (dependency, lint, cleanup, destroy, syntax, create, prepare,
           converge, idempotence, side_effect, verify, cleanup, destroy).
     """
-
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -84,7 +84,7 @@ class Test(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule test` and
+        Execute the actions necessary to perform a `molecule test` and \
         returns None.
 
         :return: None
@@ -125,10 +125,7 @@ class Test(base.Base):
     help='Enable or disable parallel mode. Default is disabled.',
 )
 def test(ctx, scenario_name, driver_name, __all, destroy, parallel):  # pragma: no cover
-    """
-    Test (dependency, lint, cleanup, destroy, syntax, create, prepare,
-          converge, idempotence, side_effect, verify, cleanup, destroy).
-    """
+    """Test (dependency, lint, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy)."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -32,6 +32,8 @@ MOLECULE_PARALLEL = os.environ.get('MOLECULE_PARALLEL', False)
 
 class Test(base.Base):
     """
+    Test Command Class.
+
     .. program:: molecule test
 
     .. option:: molecule test

--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -28,6 +28,8 @@ LOG = logger.get_logger(__name__)
 
 class Verify(base.Base):
     """
+    Verify Command Class.
+
     .. program:: molecule verify
 
     .. option:: molecule verify

--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -62,7 +62,7 @@ class Verify(base.Base):
 
     def execute(self):
         """
-        Execute the actions necessary to perform a `molecule verify` and
+        Execute the actions necessary to perform a `molecule verify` and \
         returns None.
 
         :return: None
@@ -82,7 +82,7 @@ class Verify(base.Base):
     ),
 )
 def verify(ctx, scenario_name):  # pragma: no cover
-    """ Run automated tests against instances. """
+    """Run automated tests against instances."""
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -57,6 +57,8 @@ class NewInitCaller(type):
 @six.add_metaclass(NewInitCaller)
 class Config(object):
     """
+    Config class
+
     Molecule searches the current directory for ``molecule.yml`` files by
     globbing `molecule/*/molecule.yml`.  The files are instantiated into
     a list of Molecule :class:`.Config` objects, and each Molecule subcommand
@@ -241,8 +243,9 @@ class Config(object):
 
     def _get_config(self):
         """
-        Perform a prioritized recursive merge of config files, and returns
-        a new dict.  Prior to merging the config files are interpolated with
+        Perform a prioritized recursive merge of config files.
+
+        Returns a new dict.  Prior to merging the config files are interpolated with
         environment variables.
 
         :return: dict
@@ -251,8 +254,9 @@ class Config(object):
 
     def _reget_config(self):
         """
-        Perform the same prioritized recursive merge from `get_config`, this
-        time, interpolating the ``keep_string`` left behind in the original
+        Perform the same prioritized recursive merge from `get_config`.
+
+        Interpolates the ``keep_string`` left behind in the original
         ``get_config`` call.  This is probably __very__ bad.
 
         :return: dict
@@ -264,8 +268,9 @@ class Config(object):
 
     def _combine(self, env=os.environ, keep_string=None):
         """
-        Perform a prioritized recursive merge of config files, and returns
-        a new dict.  Prior to merging the config files are interpolated with
+        Perform a prioritized recursive merge of config files.
+
+        Returns a new dict.  Prior to merging the config files are interpolated with
         environment variables.
 
         1. Loads Molecule defaults.

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -57,7 +57,7 @@ class NewInitCaller(type):
 @six.add_metaclass(NewInitCaller)
 class Config(object):
     """
-    Config class
+    Config Class.
 
     Molecule searches the current directory for ``molecule.yml`` files by
     globbing `molecule/*/molecule.yml`.  The files are instantiated into

--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -110,7 +110,7 @@ class AnsibleGalaxy(base.Base):
 
     def bake(self):
         """
-        Bake an ``ansible-galaxy`` command so it's ready to execute and returns
+        Bake an ``ansible-galaxy`` command so it's ready to execute and returns \
         None.
 
         :return: None

--- a/molecule/dependency/shell.py
+++ b/molecule/dependency/shell.py
@@ -31,8 +31,10 @@ LOG = logger.get_logger(__name__)
 
 class Shell(base.Base):
     """
-    ``Shell`` is an alternate dependency manager.  It is intended to run a
-    command in situations where `Ansible Galaxy`_ and `Gilt`_ don't suffice.
+    ``Shell`` is an alternate dependency manager.
+
+    It is intended to run a command in situations where `Ansible Galaxy`_ and
+    `Gilt`_ don't suffice.
 
     The ``command`` to execute is required, and is relative to Molecule's
     project directory when referencing a script not in $PATH.

--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -74,7 +74,7 @@ class Driver(object):
     @abc.abstractproperty
     def login_cmd_template(self):  # pragma: no cover
         """
-        The login command template to be populated by ``login_options`` and
+        The login command template to be populated by ``login_options`` and \
         returns a string.
 
         :returns: str
@@ -112,7 +112,7 @@ class Driver(object):
     @abc.abstractmethod
     def ansible_connection_options(self, instance_name):  # pragma: no cover
         """
-        Ansible specific connection options supplied to inventory and returns a
+        Ansible specific connection options supplied to inventory and returns a \
         dict.
 
         :param instance_name: A string containing the instance to login to.
@@ -123,6 +123,8 @@ class Driver(object):
     @abc.abstractmethod
     def sanity_checks(self):
         """
+        Confirms that driver is usable
+
         Sanity checks to ensure the driver can do work successfully. For
         example, when using the Docker driver, we want to know that the Docker
         daemon is running and we have the correct Docker Python dependency.

--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -123,7 +123,7 @@ class Driver(object):
     @abc.abstractmethod
     def sanity_checks(self):
         """
-        Confirms that driver is usable
+        Confirms that driver is usable.
 
         Sanity checks to ensure the driver can do work successfully. For
         example, when using the Docker driver, we want to know that the Docker

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -27,8 +27,9 @@ LOG = logger.get_logger(__name__)
 
 class Delegated(Driver):
     r"""
-    The class responsible for managing delegated instances.  Delegated is `not`
-    the default driver used in Molecule.
+    The class responsible for managing delegated instances.
+
+    Delegated is `not` the default driver used in Molecule.
 
     Under this driver, it is the developers responsibility to implement the
     create and destroy playbooks.  ``Managed`` is the default behaviour of all

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -26,7 +26,7 @@ LOG = logger.get_logger(__name__)
 
 
 class Delegated(Driver):
-    """
+    r"""
     The class responsible for managing delegated instances.  Delegated is `not`
     the default driver used in Molecule.
 
@@ -86,10 +86,10 @@ class Delegated(Driver):
 
     .. code-block:: bash
 
-        $ docker run \\
-            -d \\
-            --name instance-docker \\
-            --hostname instance-docker \\
+        $ docker run \
+            -d \
+            --name instance-docker \
+            --hostname instance-docker \
             -it molecule_local/ubuntu:latest sleep infinity & wait
 
     Use Molecule with delegated instances, which are accessible over ssh.

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -32,7 +32,7 @@ log = logger.get_logger(__name__)
 
 class Docker(Driver):
     """
-    Docker Driver Class
+    Docker Driver Class.
 
     The class responsible for managing `Docker`_ containers.  `Docker`_ is
     the default driver used in Molecule.

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -32,6 +32,8 @@ log = logger.get_logger(__name__)
 
 class Docker(Driver):
     """
+    Docker Driver Class
+
     The class responsible for managing `Docker`_ containers.  `Docker`_ is
     the default driver used in Molecule.
 

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -213,7 +213,6 @@ class Docker(Driver):
     @lru_cache()
     def sanity_checks(self):
         """Implement Docker driver sanity checks."""
-
         log.info("Sanity checks: '{}'".format(self._name))
 
         from ansible.module_utils.docker.common import HAS_DOCKER_PY

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -181,5 +181,4 @@ class Podman(Driver):
     @lru_cache()
     def sanity_checks(self):
         """Implement Podman driver sanity checks."""
-
         log.info("Sanity checks: '{}'".format(self._name))

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -31,8 +31,9 @@ log = logger.get_logger(__name__)
 
 class Podman(Driver):
     """
-    The class responsible for managing `Podman`_ containers.  `Podman`_ is
-    not default driver used in Molecule.
+    The class responsible for managing `Podman`_ containers.
+
+    `Podman`_ is not default driver used in Molecule.
 
     Molecule uses Podman ansible connector and podman CLI while mapping
     variables from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.

--- a/molecule/interpolation.py
+++ b/molecule/interpolation.py
@@ -26,9 +26,10 @@ class InvalidInterpolation(Exception):
 
 class Interpolator(object):
     """
-    Configuration options may contain environment variables.  For example,
-    suppose the shell contains ``VERIFIER_NAME=testinfra`` and the following
-    molecule.yml is supplied.
+    Configuration options may contain environment variables.
+
+    For example, suppose the shell contains ``VERIFIER_NAME=testinfra`` and
+    the following molecule.yml is supplied.
 
     .. code-block:: yaml
 

--- a/molecule/logger.py
+++ b/molecule/logger.py
@@ -73,9 +73,7 @@ class CustomLogger(logging.getLoggerClass()):
 
 
 class TrailingNewlineFormatter(logging.Formatter):
-    """
-    A custom logging formatter which removes additional newlines from messages.
-    """
+    """A custom logging formatter which removes additional newlines from messages."""
 
     def format(self, record):
         if record.msg:

--- a/molecule/logger.py
+++ b/molecule/logger.py
@@ -39,10 +39,7 @@ OUT = 101
 
 
 class LogFilter(object):
-    """
-    A custom log filter which excludes log messages above the logged
-    level.
-    """
+    """A custom log filter which excludes log messages above the logged level."""
 
     def __init__(self, level):
         self.__level = level
@@ -54,8 +51,9 @@ class LogFilter(object):
 
 class CustomLogger(logging.getLoggerClass()):
     """
-    A custom logging class which adds additional methods to the logger.  These
-    methods serve as syntactic sugar for formatting log messages.
+    A custom logging class which adds additional methods to the logger.
+
+    These methods serve as syntactic sugar for formatting log messages.
     """
 
     def __init__(self, name, level=logging.NOTSET):

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -459,7 +459,7 @@ class Validator(cerberus.Validator):
                     self._error(field, msg)
 
     def _validate_disallowed(self, disallowed, field, value):
-        """ Readonly but with a custom error.
+        """Readonly but with a custom error.
 
         The rule's arguments are validated against this schema:
         {'type': 'boolean'}
@@ -480,7 +480,7 @@ class Validator(cerberus.Validator):
         return value
 
     def _validate_molecule_env_var(self, molecule_env_var, field, value):
-        """ Readonly but with a custom error.
+        """Readonly but with a custom error.
 
         The rule's arguments are validated against this schema:
         {'type': 'boolean'}

--- a/molecule/platforms.py
+++ b/molecule/platforms.py
@@ -26,7 +26,7 @@ LOG = logger.get_logger(__name__)
 
 class Platforms(object):
     """
-    Platforms define the instances to be tested, and the groups to which the
+    Platforms define the instances to be tested, and the groups to which the \
     instances belong.
 
     .. code-block:: yaml

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -34,7 +34,7 @@ LOG = logger.get_logger(__name__)
 
 class Ansible(base.Base):
     """
-    `Ansible`_ is the default provisioner.  No other provisioner will be
+    `Ansible`_ is the default provisioner.  No other provisioner will be \
     supported.
 
     Molecule's provisioner manages the instances lifecycle.  However, the user
@@ -645,7 +645,7 @@ class Ansible(base.Base):
 
     def cleanup(self):
         """
-        Executes `ansible-playbook` against the cleanup playbook and returns
+        Executes `ansible-playbook` against the cleanup playbook and returns \
         None.
 
         :return: None
@@ -662,7 +662,7 @@ class Ansible(base.Base):
 
     def check(self):
         """
-        Executes ``ansible-playbook`` against the converge playbook with the
+        Executes ``ansible-playbook`` against the converge playbook with the \
         ``--check`` flag and returns None.
 
         :return: None
@@ -673,7 +673,7 @@ class Ansible(base.Base):
 
     def converge(self, playbook=None, **kwargs):
         """
-        Executes ``ansible-playbook`` against the converge playbook unless
+        Executes ``ansible-playbook`` against the converge playbook unless \
         specified otherwise and returns a string.
 
         :param playbook: An optional string containing an absolute path to a
@@ -690,7 +690,7 @@ class Ansible(base.Base):
 
     def destroy(self):
         """
-        Executes ``ansible-playbook`` against the destroy playbook and returns
+        Executes ``ansible-playbook`` against the destroy playbook and returns \
         None.
 
         :return: None
@@ -700,7 +700,7 @@ class Ansible(base.Base):
 
     def side_effect(self):
         """
-        Executes ``ansible-playbook`` against the side_effect playbook and
+        Executes ``ansible-playbook`` against the side_effect playbook and \
         returns None.
 
         :return: None
@@ -710,7 +710,7 @@ class Ansible(base.Base):
 
     def create(self):
         """
-        Executes ``ansible-playbook`` against the create playbook and returns
+        Executes ``ansible-playbook`` against the create playbook and returns \
         None.
 
         :return: None
@@ -720,7 +720,7 @@ class Ansible(base.Base):
 
     def prepare(self):
         """
-        Executes ``ansible-playbook`` against the prepare playbook and returns
+        Executes ``ansible-playbook`` against the prepare playbook and returns \
         None.
 
         :return: None
@@ -730,7 +730,7 @@ class Ansible(base.Base):
 
     def syntax(self):
         """
-        Executes ``ansible-playbook`` against the converge playbook with the
+        Executes ``ansible-playbook`` against the converge playbook with the \
         ``-syntax-check`` flag and returns None.
 
         :return: None
@@ -741,7 +741,7 @@ class Ansible(base.Base):
 
     def verify(self):
         """
-        Executes ``ansible-playbook`` against the verify playbook and returns
+        Executes ``ansible-playbook`` against the verify playbook and returns \
         None.
 
         :return: None

--- a/molecule/provisioner/ansible/plugins/filter/molecule_core.py
+++ b/molecule/provisioner/ansible/plugins/filter/molecule_core.py
@@ -66,7 +66,7 @@ def get_docker_networks(data):
 
 
 class FilterModule(object):
-    """ Core Molecule filter plugins. """
+    """Core Molecule filter plugins."""
 
     def filters(self):
         return {

--- a/molecule/provisioner/ansible_playbook.py
+++ b/molecule/provisioner/ansible_playbook.py
@@ -29,7 +29,7 @@ LOG = logger.get_logger(__name__)
 class AnsiblePlaybook(object):
     def __init__(self, playbook, config, out=LOG.out, err=LOG.error):
         """
-        Sets up the requirements to execute ``ansible-playbook`` and returns
+        Sets up the requirements to execute ``ansible-playbook`` and returns \
         None.
 
         :param playbook: A string containing the path to the playbook.
@@ -50,7 +50,7 @@ class AnsiblePlaybook(object):
 
     def bake(self):
         """
-        Bake an ``ansible-playbook`` command so it's ready to execute and
+        Bake an ``ansible-playbook`` command so it's ready to execute and \
         returns ``None``.
 
         :return: None
@@ -112,7 +112,7 @@ class AnsiblePlaybook(object):
 
     def add_env_arg(self, name, value):
         """
-        Adds argument to environment passed to ansible-playbook and returns
+        Adds argument to environment passed to ansible-playbook and returns \
         None.
 
         :param name: A string containing the name of argument to be added.

--- a/molecule/provisioner/ansible_playbooks.py
+++ b/molecule/provisioner/ansible_playbooks.py
@@ -29,7 +29,7 @@ LOG = logger.get_logger(__name__)
 
 
 class AnsiblePlaybooks(object):
-    """ A class to act as a module to namespace playbook properties. """
+    """A class to act as a module to namespace playbook properties."""
 
     def __init__(self, config):
         """

--- a/molecule/provisioner/lint/ansible_lint.py
+++ b/molecule/provisioner/lint/ansible_lint.py
@@ -63,8 +63,7 @@ class AnsibleLintMixin:
 
     def bake(self):
         """
-        Bake an `ansible-lint` command so it's ready to execute and returns
-        None.
+        Bake an `ansible-lint` command so it's ready to execute and returns None.
 
         :return: None
         """

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -244,10 +244,10 @@ class Scenario(object):
 
     def _setup(self):
         """
-         Prepare the scenario for Molecule and returns None.
+        Prepare the scenario for Molecule and returns None.
 
-         :return: None
-         """
+        :return: None
+        """
         if not os.path.isdir(self.inventory_directory):
             os.makedirs(self.inventory_directory)
 

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -36,7 +36,7 @@ LOG = logger.get_logger(__name__)
 
 class Scenario(object):
     """
-    A scenario allows Molecule test a role in a particular way, this is a
+    A scenario allows Molecule test a role in a particular way, this is a \
     fundamental change from Molecule v1.
 
     A scenario is a self-contained directory containing everything necessary
@@ -226,7 +226,7 @@ class Scenario(object):
     @property
     def sequence(self):
         """
-        Select the sequence based on scenario and subcommand of the provided
+        Select the sequence based on scenario and subcommand of the provided \
         scenario object and returns a list.
 
         :param scenario: A scenario object.
@@ -254,9 +254,10 @@ class Scenario(object):
 
 def ephemeral_directory(path=None):
     """
-    Returns temporary directory to be used by molecule. Molecule users should
-    not make any assumptions about its location, permissions or its content as
-    this may change in future release.
+    Returns temporary directory to be used by molecule.
+
+    Molecule users should not make any assumptions about its location,
+    permissions or its content as this may change in future release.
     """
     d = os.getenv('MOLECULE_EPHEMERAL_DIRECTORY')
     if not d:

--- a/molecule/scenarios.py
+++ b/molecule/scenarios.py
@@ -29,10 +29,8 @@ LOG = logger.get_logger(__name__)
 
 
 class Scenarios(object):
-    """
-    The Scenarios object consists of one to many scenario objects Molecule will
-    execute.
-    """
+    """The Scenarios object consists of one to many scenario objects Molecule will \
+    execute."""
 
     def __init__(self, configs, scenario_name=None):
         """
@@ -109,7 +107,7 @@ class Scenarios(object):
 
     def _filter_for_scenario(self):
         """
-        Find the scenario matching the provided scenario name and returns a
+        Find the scenario matching the provided scenario name and returns a \
         list.
 
         :return: list
@@ -120,7 +118,7 @@ class Scenarios(object):
 
     def _get_matrix(self):
         """
-        Build a matrix of scenarios with sequence to include and returns a
+        Build a matrix of scenarios with sequence to include and returns a \
         dict.
 
         {

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -64,12 +64,6 @@ ENV_FILE = '.env.yml'
 @click.pass_context
 def main(ctx, debug, base_config, env_file):  # pragma: no cover
     """
-    \b
-     _____     _             _
-    |     |___| |___ ___ _ _| |___
-    | | | | . | | -_|  _| | | | -_|
-    |_|_|_|___|_|___|___|___|_|___|
-
     Molecule aids in the development and testing of Ansible roles.
 
     Enable autocomplete issue:

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -34,12 +34,12 @@ class InvalidState(Exception):
 
 
 class State(object):
-    """
-    A class which manages the state file.  Intended to be used as a singleton
-    throughout a given Molecule config.  The initial state is serialized to
-    disk if the file does not exist, otherwise is deserialized from the
-    existing state file.  Changes made to the object are immediately
-    serialized.
+    """A class which manages the state file.
+
+    Intended to be used as a singleton throughout a given Molecule config.
+    The initial state is serialized to disk if the file does not exist,
+    otherwise is deserialized from the existing state file.  Changes made to
+    the object are immediately serialized.
 
     State is not a top level option in Molecule's config.  It's purpose is for
     bookkeeping, and each :class:`.Config` object has a reference to a State_
@@ -105,7 +105,7 @@ class State(object):
     @marshal
     def change_state(self, key, value):
         """
-        Changes the state of the instance data with the given
+        Changes the state of the instance data with the given \
         ``key`` and the provided ``value``.
 
         Wrapping with a decorator is probably not necessary.

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -28,9 +28,7 @@ VALID_KEYS = ['created', 'converged', 'driver', 'prepared', 'run_uuid', 'is_para
 
 
 class InvalidState(Exception):
-    """
-    Exception class raised when an error occurs in :class:`.State`.
-    """
+    """Exception class raised when an error occurs in :class:`.State`."""
 
     pass
 

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -164,7 +164,7 @@ def molecule_prepender(content):
 
 def file_prepender(filename):
     """
-    Prepend an informational header on files managed by Molecule and returns
+    Prepend an informational header on files managed by Molecule and returns \
     None.
 
     :param filename: A string containing the target filename.
@@ -289,8 +289,9 @@ def underscore(string):
 
 def merge_dicts(a, b):
     """
-    Merges the values of b into a and returns a new dict. This function uses
-    the same algorithm as Ansible's `combine(recursive=True)` filter.
+    Merges the values of b into a and returns a new dict.
+
+    This function uses the same algorithm as Ansible's `combine(recursive=True)` filter.
 
     :param a: the target dictionary
     :param b: the dictionary to import

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -156,7 +156,6 @@ class Testinfra(Verifier):
 
         :return: None
         """
-
         options = self.options
         verbose_flag = util.verbose_flag(options)
         args = verbose_flag + self.additional_files_or_dirs


### PR DESCRIPTION
* Fixes few rules:
[D200] One-line docstring should fit on one line with quotes
[D202] No blank lines allowed after function docstring
[D208] Docstring is over-indented
[D301] Use r""" if any backslashes in a docstring

* Temporary ignores other broken rules.
* Drops ASCII art from docstring as it was not compliant

Partial: #2507 