### PR TITLE
Use prebuild images in scenario template

### DIFF
--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -8,10 +8,12 @@ lint:
 platforms:
 {%- if cookiecutter.driver_name == 'docker' %}
   - name: instance
-    image: docker.io/centos:7
+    image: docker.io/pycontribs/centos:7
+    pre_build_image: true
 {%- elif cookiecutter.driver_name == 'podman' %}
   - name: instance
-    image: docker.io/centos:7
+    image: docker.io/pycontribs/centos:7
+    pre_build_image: true
 {%- else %}
   - name: instance
 {%- endif %}


### PR DESCRIPTION
By defaulting to use of pre-build images on default scenario we
save a significant amount of functional testing time.