### PR TITLE
Prevent accidental test regressions on CI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,9 @@
 """PyTest Config File."""
 
+from __future__ import print_function
 import os
 import pytest
+import sys
 
 pytest_plugins = ['helpers_namespace']
 
@@ -17,3 +19,29 @@ def environ():
     # adds extra environment variables that may be needed during testing
     if not os.environ.get('TEST_BASE_IMAGE', ""):
         os.environ['TEST_BASE_IMAGE'] = 'docker.io/pycontribs/centos:7'
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Assure passed test match PYTEST_REQPASS value.
+
+    Assures that pytest returns an error code when the number of expected passed
+    tests does not match the PYTEST_REQPASS value.  When not defined or zero
+    that functionality is ignored.
+    """
+    yield
+    req_passed = int(os.environ.get('PYTEST_REQPASS', '0'))
+    if req_passed and not config.option.collectonly:
+        passed = 0
+        for x in terminalreporter.stats.get('passed', []):
+            if x.when == 'call' and x.outcome == 'passed':
+                passed += 1
+        if passed != req_passed:
+            print(
+                'ERROR: {} passed test but expected number was {}. '
+                ' If that is expected please update PYTEST_REQPASS value for the failed job in zuul.d/layout.yaml file.'.format(
+                    passed, req_passed
+                ),
+                file=sys.stderr,
+            )
+            sys.exit(127)

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,6 +118,7 @@ test =
     pytest-html>=1.21.0; python_version >= '3.6'
     pytest-mock>=1.10.4, < 2
     pytest-verbose-parametrize>=1.7.0, < 2
+    pytest-sugar>=0.9.2, < 1
     pytest-xdist>=1.29.0, < 2
     pytest>=4.6.3, < 5
     shade>=1.31.0, < 2

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -5,6 +5,8 @@
     parent: molecule-tox-py27
     vars:
       tox_envlist: py27-ansible28-unit
+      tox_environment:
+        PYTEST_REQPASS: 558
 
 - job:
     name: molecule-tox-py27-ansible28-functional
@@ -12,12 +14,16 @@
     timeout: 7200
     vars:
       tox_envlist: py27-ansible28-functional
+      tox_environment:
+        PYTEST_REQPASS: 54
 
 - job:
     name: molecule-tox-py27-ansible29-unit
     parent: molecule-tox-py27
     vars:
       tox_envlist: py27-ansible29-unit
+      tox_environment:
+        PYTEST_REQPASS: 558
 
 - job:
     name: molecule-tox-py27-ansible29-functional
@@ -25,12 +31,16 @@
     timeout: 7200
     vars:
       tox_envlist: py27-ansible29-functional
+      tox_environment:
+        PYTEST_REQPASS: 54
 
 - job:
     name: molecule-tox-py36-ansible29-unit
     parent: molecule-tox-py36
     vars:
       tox_envlist: py36-ansible29-unit
+      tox_environment:
+        PYTEST_REQPASS: 558
 
 - job:
     name: molecule-tox-py36-ansible29-functional
@@ -38,12 +48,16 @@
     timeout: 7200
     vars:
       tox_envlist: py36-ansible29-functional
+      tox_environment:
+        PYTEST_REQPASS: 54
 
 - job:
     name: molecule-tox-py37-ansible28-unit
     parent: molecule-tox-py37
     vars:
       tox_envlist: py37-ansible28-unit
+      tox_environment:
+        PYTEST_REQPASS: 558
 
 - job:
     name: molecule-tox-py37-ansible28-functional
@@ -51,12 +65,16 @@
     timeout: 7200
     vars:
       tox_envlist: py37-ansible28-functional
+      tox_environment:
+        PYTEST_REQPASS: 54
 
 - job:
     name: molecule-tox-py37-ansible29-unit
     parent: molecule-tox-py37
     vars:
       tox_envlist: py37-ansible29-unit
+      tox_environment:
+        PYTEST_REQPASS: 558
 
 - job:
     name: molecule-tox-py37-ansible29-functional
@@ -64,12 +82,16 @@
     timeout: 7200
     vars:
       tox_envlist: py37-ansible29-functional
+      tox_environment:
+        PYTEST_REQPASS: 54
 
 - job:
     name: molecule-tox-devel-unit
     parent: molecule-tox-py36
     vars:
       tox_envlist: ansibledevel-unit
+      tox_environment:
+        PYTEST_REQPASS: 558
 
 - job:
     name: molecule-tox-devel-functional
@@ -77,12 +99,16 @@
     timeout: 7200
     vars:
       tox_envlist: ansibledevel-functional
+      tox_environment:
+        PYTEST_REQPASS: 54
 
 - job:
     name: molecule-tox-py27-ansible28-unit
     parent: molecule-tox-py27
     vars:
       tox_envlist: py27-ansible28-unit
+      tox_environment:
+        PYTEST_REQPASS: 558
 
 - job:
     name: molecule-tox-py27-ansible28-functional
@@ -90,12 +116,16 @@
     timeout: 7200
     vars:
       tox_envlist: py27-ansible28-functional
+      tox_environment:
+        PYTEST_REQPASS: 54
 
 - job:
     name: molecule-tox-py37-ansible28-unit
     parent: molecule-tox-py37
     vars:
       tox_envlist: py37-ansible28-unit
+      tox_environment:
+        PYTEST_REQPASS: 558
 
 - job:
     name: molecule-tox-py37-ansible28-functional
@@ -103,6 +133,8 @@
     timeout: 7200
     vars:
       tox_envlist: py37-ansible28-functional
+      tox_environment:
+        PYTEST_REQPASS: 54
 
 - job:
     name: molecule-tox-packaging


### PR DESCRIPTION
Introduces a PYTEST_REQPASS option that makes pytest fail if the
number of passed tests does not exactly match number its value.

This should prevent accidents where some tests are not run due to other
changes made to the test environment.

We had at least one case where `--delegated` feature prevented
execution of some tests in CI and we ended up with more broken tests.

This change does affect only CI execution because a failure happens
only when this variable is defined.
