### PR TITLE
Allow platform env key containing dot (#2495)

### DIFF
--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -355,7 +355,7 @@ platforms_docker_schema = {
                 },
                 'env': {
                     'type': 'dict',
-                    'keysrules': {'type': 'string', 'regex': '^[a-zA-Z0-9_-]+$'},
+                    'keysrules': {'type': 'string', 'regex': '^[a-zA-Z0-9._-]+$'},
                 },
                 'restart_policy': {'type': 'string'},
                 'restart_retries': {'type': 'integer'},
@@ -422,7 +422,7 @@ platforms_podman_schema = {
                 },
                 'env': {
                     'type': 'dict',
-                    'keysrules': {'type': 'string', 'regex': '^[a-zA-Z0-9_-]+$'},
+                    'keysrules': {'type': 'string', 'regex': '^[a-zA-Z0-9._-]+$'},
                 },
                 'restart_policy': {'type': 'string'},
                 'restart_retries': {'type': 'integer'},

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -6,7 +6,7 @@
     vars:
       tox_envlist: py27-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 558
+        PYTEST_REQPASS: 559
 
 - job:
     name: molecule-tox-py27-ansible28-functional
@@ -23,7 +23,7 @@
     vars:
       tox_envlist: py27-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 558
+        PYTEST_REQPASS: 559
 
 - job:
     name: molecule-tox-py27-ansible29-functional
@@ -40,7 +40,7 @@
     vars:
       tox_envlist: py36-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 558
+        PYTEST_REQPASS: 559
 
 - job:
     name: molecule-tox-py36-ansible29-functional
@@ -57,7 +57,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 558
+        PYTEST_REQPASS: 559
 
 - job:
     name: molecule-tox-py37-ansible28-functional
@@ -74,7 +74,7 @@
     vars:
       tox_envlist: py37-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 558
+        PYTEST_REQPASS: 559
 
 - job:
     name: molecule-tox-py37-ansible29-functional
@@ -91,7 +91,7 @@
     vars:
       tox_envlist: ansibledevel-unit
       tox_environment:
-        PYTEST_REQPASS: 558
+        PYTEST_REQPASS: 559
 
 - job:
     name: molecule-tox-devel-functional
@@ -108,7 +108,7 @@
     vars:
       tox_envlist: py27-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 558
+        PYTEST_REQPASS: 559
 
 - job:
     name: molecule-tox-py27-ansible28-functional
@@ -125,7 +125,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 558
+        PYTEST_REQPASS: 559
 
 - job:
     name: molecule-tox-py37-ansible28-functional


### PR DESCRIPTION
- Env variable with dot ('.') is now accepted by schema validator
  - Schema regexp updated (add '.')
  - Unit tests for platforms schema updated with: 
     - default variables containing dot ('.') and dash ('-')  => validation should be OK
     - add one test using badly formated variables containing other special char => validation should fail

Fixes: #2495