### PR TITLE
Make linters an optional dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,7 +41,7 @@ Keep in mind that on selinux supporting systems, if you install into a virtual
 environment, you may face :gh:`issue <ansible/ansible/issues/34340>` even
 if selinux is not enabled or is configured to be permissive.
 
-It is your reponsability to assure that soft dependencies of Ansible are
+It is your responsibility to assure that soft dependencies of Ansible are
 available on your controller or host machines.
 
 .. warning::
@@ -79,7 +79,7 @@ Install Molecule:
 
 .. code-block:: bash
 
-    $ pip install --user molecule
+    $ pip install --user "molecule[lint]"
 
 Installing molecule package also installed its main script ``molecule``,
 usually in ``PATH``. Users should know that molecule can also be called as a

--- a/molecule/command/list.py
+++ b/molecule/command/list.py
@@ -35,7 +35,11 @@ LOG = logger.get_logger(__name__)
 
 class List(base.Base):
     """
-    List Command Class.
+    Lint command executes external linters.
+
+    You need to remember to install those linters. For concenience, there is a
+    package extra that installs the most common ones, use it like
+    ``pip install "molecule[extra]"``.
 
     .. program:: molecule list
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,10 +68,8 @@ setup_requires =
 # These are required in actual runtime:
 install_requires =
     ansible >= 2.8  # keep it N/N-1
-    ansible-lint >= 4.1.1a2, < 5
 
     backports.functools_lru_cache; python_version<"3.3"
-    flake8 >=3.6.0
     cerberus >= 1.3.1
     click >= 7.0
     click-completion >= 0.5.1
@@ -83,7 +81,7 @@ install_requires =
     pathlib2; python_version<"3.2"
     pexpect >= 4.6.0, < 5
     pluggy >= 0.7.1, < 1.0
-    pre-commit >= 1.17.0
+    pre-commit >= 1.17.0, < 2
     PyYAML >= 5.1, < 6
     sh >= 1.12.14
     six >= 1.11.0
@@ -91,7 +89,6 @@ install_requires =
     tabulate >= 0.8.4
     testinfra >= 3.0.6, < 4
     tree-format >= 0.1.2
-    yamllint >= 1.15.0, < 2
 
 [options.extras_require]
 docs =
@@ -122,6 +119,11 @@ test =
     pytest-xdist>=1.29.0, < 2
     pytest>=4.6.3, < 5
     shade>=1.31.0, < 2
+lint =
+    ansible-lint >= 4.1.1a2, < 5
+    flake8 >=3.6.0
+    pre-commit >= 1.17.0
+    yamllint >= 1.15.0
 
 [options.entry_points]
 console_scripts =

--- a/tox.ini
+++ b/tox.ini
@@ -37,9 +37,10 @@ deps =
     selinux
 extras =
     docker
+    lint
     podman
-    windows
     test
+    windows
 commands_pre =
     find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -path '*/__pycache__/*' -name '*.py[c|o]' -delete
     sh -c 'find {homedir}/.cache -type d -path "*/molecule_*" -exec rm -rfv \{\} +;'


### PR DESCRIPTION
Makes installation of linters optional in molecule, allowing it to be installed without installing them. If you are using them you will need to either add them as dependencies or use the newly
introduced 'lint' extra when you install molecule.