### PR TITLE
Colorize command line help

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -31,6 +31,9 @@ import molecule.scenarios
 from molecule import config
 from molecule import logger
 from molecule import util
+import click
+from click_help_colors import HelpColorsCommand, HelpColorsGroup
+
 
 LOG = logger.get_logger(__name__)
 MOLECULE_GLOB = os.environ.get('MOLECULE_GLOB', 'molecule/*/molecule.yml')
@@ -198,3 +201,32 @@ def _verify_configs(configs):
 
 def _get_subcommand(string):
     return string.split('.')[-1]
+
+
+def click_group_ex():
+    """Return extended version of click.group()."""
+    # Color coding used to group command types, documented only here as we may
+    # decide to change them later.
+    # green : (default) as sequence step
+    # blue : molecule own command, not dependent on scenario
+    # yellow : special commands, like full test sequence, or login
+    return click.group(
+        cls=HelpColorsGroup,
+        help_headers_color='yellow',
+        help_options_color='green',
+        help_options_custom_colors={
+            'drivers': 'blue',
+            'init': 'blue',
+            'list': 'blue',
+            'matrix': 'blue',
+            'login': 'bright_yellow',
+            'test': 'bright_yellow',
+        },
+    )
+
+
+def click_command_ex():
+    """Return extended version of click.command()."""
+    return click.command(
+        cls=HelpColorsCommand, help_headers_color='yellow', help_options_color='green'
+    )

--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -26,6 +26,7 @@ from molecule import logger
 from molecule.command import base
 from molecule import util
 
+
 LOG = logger.get_logger(__name__)
 MOLECULE_PARALLEL = os.environ.get('MOLECULE_PARALLEL', False)
 
@@ -83,7 +84,7 @@ class Check(base.Base):
         self._config.provisioner.check()
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/cleanup.py
+++ b/molecule/command/cleanup.py
@@ -83,7 +83,7 @@ class Cleanup(base.Base):
         self._config.provisioner.cleanup()
 
 
-@click.command(name='cleanup')
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -84,7 +84,7 @@ class Converge(base.Base):
         self._config.state.change_state('converged', True)
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -95,7 +95,7 @@ class Create(base.Base):
         self._config.state.change_state('created', True)
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -74,7 +74,7 @@ class Dependency(base.Base):
         self._config.dependency.execute()
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -108,7 +108,7 @@ class Destroy(base.Base):
         self._config.state.reset()
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/drivers.py
+++ b/molecule/command/drivers.py
@@ -26,11 +26,12 @@ import tabulate
 
 from molecule import logger
 from molecule import api
+from molecule.command import base
 
 LOG = logger.get_logger(__name__)
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--format',

--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -137,7 +137,7 @@ class Idempotence(base.Base):
         return res
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/init/init.py
+++ b/molecule/command/init/init.py
@@ -19,8 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 """Base class used by init command."""
 
-import click
-
+from molecule.command import base
 from molecule import logger
 from molecule.command.init import role
 from molecule.command.init import scenario
@@ -28,7 +27,7 @@ from molecule.command.init import scenario
 LOG = logger.get_logger(__name__)
 
 
-@click.group()
+@base.click_group_ex()
 def init():  # pragma: no cover
     """Initialize a new role or scenario."""
 

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -97,7 +97,7 @@ class Role(base.Base):
         LOG.success(msg)
 
 
-@click.command()
+@command_base.click_command_ex()
 @click.pass_context
 @click.option(
     '--dependency-name',

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -148,7 +148,7 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
     return value
 
 
-@click.command()
+@command_base.click_command_ex()
 @click.pass_context
 @click.option(
     '--dependency-name',

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -85,7 +85,7 @@ class Lint(base.Base):
             l.execute()
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/list.py
+++ b/molecule/command/list.py
@@ -95,7 +95,7 @@ class List(base.Base):
         return self._config.driver.status()
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option('--scenario-name', '-s', help='Name of the scenario to target.')
 @click.option(

--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -164,7 +164,7 @@ class Login(base.Base):
         self._pt.setwinsize(a[0], a[1])
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option('--host', '-h', help='Host to access.')
 @click.option(

--- a/molecule/command/matrix.py
+++ b/molecule/command/matrix.py
@@ -65,7 +65,7 @@ class Matrix(base.Base):
     """
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option('--scenario-name', '-s', help='Name of the scenario to target.')
 # NOTE(retr0h): Cannot introspect base.Base for `click.Choice`, since

--- a/molecule/command/prepare.py
+++ b/molecule/command/prepare.py
@@ -104,7 +104,7 @@ class Prepare(base.Base):
         self._config.state.change_state('prepared', True)
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/side_effect.py
+++ b/molecule/command/side_effect.py
@@ -81,7 +81,7 @@ class SideEffect(base.Base):
         self._config.provisioner.side_effect()
 
 
-@click.command(name='side-effect')
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/syntax.py
+++ b/molecule/command/syntax.py
@@ -73,7 +73,7 @@ class Syntax(base.Base):
         self._config.provisioner.syntax()
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -94,7 +94,7 @@ class Test(base.Base):
         """
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -74,7 +74,7 @@ class Verify(base.Base):
         self._config.verifier.execute()
 
 
-@click.command()
+@base.click_command_ex()
 @click.pass_context
 @click.option(
     '--scenario-name',

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -31,6 +31,7 @@ import molecule
 from molecule import command
 from molecule.config import MOLECULE_DEBUG
 from molecule.logger import should_do_markup
+from molecule.command.base import click_group_ex
 
 click_completion.init()
 colorama.init(autoreset=True, strip=not should_do_markup())
@@ -39,7 +40,7 @@ LOCAL_CONFIG = os.path.expanduser('~/.config/molecule/config.yml')
 ENV_FILE = '.env.yml'
 
 
-@click.group()
+@click_group_ex()
 @click.option(
     '--debug/--no-debug',
     default=MOLECULE_DEBUG,

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ install_requires =
     cerberus >= 1.3.1
     click >= 7.0
     click-completion >= 0.5.1
+    click-help-colors >= 0.6
     colorama >= 0.3.9
     cookiecutter >= 1.6.0
     python-gilt >= 1.2.1, < 2


### PR DESCRIPTION
Improves readability of command line help by adding coloring to it.

![screenshot](https://sbarnea.com/ss/Screen-Shot-2020-02-02-08-29-08.74.png)
