### PR TITLE
Shell dependency: use proper lexical parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Changelog
 * Use pluggy to load plugins
 * Windows & Linux EC2 instances can be tested simultaneously
 * Windows EC2 instances can be provisioned using the automatically-generated password
+* Shell dependency manager now uses proper lexical parsing of complex command lines
 
 2.22
 ====

--- a/molecule/dependency/shell.py
+++ b/molecule/dependency/shell.py
@@ -20,6 +20,7 @@
 """Shell Dependency Module."""
 
 import os
+import shlex
 
 import sh
 
@@ -97,7 +98,7 @@ class Shell(base.Base):
 
         :return: None
         """
-        command_list = self.command.split(' ')
+        command_list = shlex.split(self.command)
         command, args = command_list[0], command_list[1:]
 
         self._sh_command = getattr(sh, command)

--- a/molecule/test/unit/dependency/test_shell.py
+++ b/molecule/test/unit/dependency/test_shell.py
@@ -101,6 +101,33 @@ def test_bake(_instance):
     assert sorted(x) == sorted(result)
 
 
+@pytest.mark.parametrize('config_instance', ['_dependency_section_data'], indirect=True)
+@pytest.mark.parametrize(
+    'command,words',
+    {
+        'ls -l -a /tmp': ['ls', '-l', '-a', '/tmp'],
+        'sh -c "echo hello world"': ['sh', '-c', 'echo hello world'],
+        'echo "hello world"': ['echo', 'hello world'],
+        '''printf "%s\\n" foo "bar baz" 'a b' c''': [
+            'printf',
+            r'%s\n',
+            'foo',
+            'bar baz',
+            'a b',
+            'c',
+        ],
+    }.items(),
+)
+def test_bake2(_instance, command, words):
+    _instance._config.config['dependency']['command'] = command
+    _instance.bake()
+    baked_exe = _instance._sh_command._path.decode()
+    baked_args = [w.decode() for w in _instance._sh_command._partial_baked_args]
+
+    assert baked_exe.endswith(words[0])
+    assert baked_args == words[1:]
+
+
 def test_execute(patched_run_command, patched_logger_success, _instance):
     _instance._sh_command = 'patched-command'
     _instance.execute()

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -6,7 +6,7 @@
     vars:
       tox_envlist: py27-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 559
+        PYTEST_REQPASS: 563
 
 - job:
     name: molecule-tox-py27-ansible28-functional
@@ -23,7 +23,7 @@
     vars:
       tox_envlist: py27-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 559
+        PYTEST_REQPASS: 563
 
 - job:
     name: molecule-tox-py27-ansible29-functional
@@ -40,7 +40,7 @@
     vars:
       tox_envlist: py36-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 559
+        PYTEST_REQPASS: 563
 
 - job:
     name: molecule-tox-py36-ansible29-functional
@@ -57,7 +57,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 559
+        PYTEST_REQPASS: 563
 
 - job:
     name: molecule-tox-py37-ansible28-functional
@@ -74,7 +74,7 @@
     vars:
       tox_envlist: py37-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 559
+        PYTEST_REQPASS: 563
 
 - job:
     name: molecule-tox-py37-ansible29-functional
@@ -91,7 +91,7 @@
     vars:
       tox_envlist: ansibledevel-unit
       tox_environment:
-        PYTEST_REQPASS: 559
+        PYTEST_REQPASS: 563
 
 - job:
     name: molecule-tox-devel-functional
@@ -108,7 +108,7 @@
     vars:
       tox_envlist: py27-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 559
+        PYTEST_REQPASS: 563
 
 - job:
     name: molecule-tox-py27-ansible28-functional
@@ -125,7 +125,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 559
+        PYTEST_REQPASS: 563
 
 - job:
     name: molecule-tox-py37-ansible28-functional


### PR DESCRIPTION
Shell dependency manager used simple splitting on whitespace for parsing command lines. That would lead to incorrect parsing and execution of more complex commands like `echo "hello world"`.

This PR introduces proper lexical parsing with shlex module from Python standard library. Unit tests and changelog entry are included.

#### PR Type

- Bugfix Pull Request