### PR TITLE
Improve schema validation errors

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -420,11 +420,10 @@ class Config(object):
     def _preflight(self, data):
         env = os.environ.copy()
         env = set_env_from_file(env, self.env_file)
-        errors = schema_v2.pre_validate(data, env, MOLECULE_KEEP_STRING)
-
+        errors, data = schema_v2.pre_validate(data, env, MOLECULE_KEEP_STRING)
         if errors:
-            msg = "Failed to validate.\n\n{}".format(errors)
-            util.sysexit_with_message(msg)
+            msg = "Failed to pre-validate.\n\n{}".format(errors)
+            util.sysexit_with_message(msg, detail=data)
 
     def _validate(self):
         msg = 'Validating schema {}.'.format(self.molecule_file)

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -507,7 +507,7 @@ def pre_validate(stream, env, keep_string):
     v = Validator(allow_unknown=True)
     v.validate(data, pre_validate_base_schema(env, keep_string))
 
-    return v.errors
+    return v.errors, data
 
 
 def validate(c):

--- a/molecule/test/unit/model/v2/test_pre_validate.py
+++ b/molecule/test/unit/model/v2/test_pre_validate.py
@@ -46,8 +46,11 @@ def _keep_string():
 
 
 def test_platforms_docker(_model_platforms_docker_section_data, _env, _keep_string):
-    assert {} == schema_v2.pre_validate(
-        _model_platforms_docker_section_data, _env, _keep_string
+    assert (
+        {}
+        == schema_v2.pre_validate(
+            _model_platforms_docker_section_data, _env, _keep_string
+        )[0]
     )
 
 
@@ -80,8 +83,11 @@ def test_platforms_docker_has_errors(
         ]
     }
 
-    assert x == schema_v2.pre_validate(
-        _model_platforms_docker_errors_section_data, _env, _keep_string
+    assert (
+        x
+        == schema_v2.pre_validate(
+            _model_platforms_docker_errors_section_data, _env, _keep_string
+        )[0]
     )
 
 
@@ -185,6 +191,9 @@ def test_has_errors_when_molecule_env_var_referenced_in_unallowed_sections(
         ],
     }
 
-    assert x == schema_v2.pre_validate(
-        _model_molecule_env_errors_section_data, _env, _keep_string
+    assert (
+        x
+        == schema_v2.pre_validate(
+            _model_molecule_env_errors_section_data, _env, _keep_string
+        )[0]
     )

--- a/molecule/test/unit/test_config.py
+++ b/molecule/test/unit/test_config.py
@@ -305,7 +305,7 @@ def test_get_defaults(config_instance, mocker):
 
 def test_preflight(mocker, config_instance, patched_logger_info):
     m = mocker.patch('molecule.model.schema_v2.pre_validate')
-    m.return_value = None
+    m.return_value = (None, None)
 
     config_instance._preflight('foo')
 
@@ -316,14 +316,14 @@ def test_preflight_exists_when_validation_fails(
     mocker, patched_logger_critical, config_instance
 ):
     m = mocker.patch('molecule.model.schema_v2.pre_validate')
-    m.return_value = 'validation errors'
+    m.return_value = ('validation errors', None)
 
     with pytest.raises(SystemExit) as e:
         config_instance._preflight('invalid stream')
 
     assert 1 == e.value.code
 
-    msg = 'Failed to validate.\n\nvalidation errors'
+    msg = 'Failed to pre-validate.\n\nvalidation errors'
     patched_logger_critical.assert_called_once_with(msg)
 
 

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -110,8 +110,14 @@ def sysexit(code=1):
     sys.exit(code)
 
 
-def sysexit_with_message(msg, code=1):
+def sysexit_with_message(msg, code=1, detail=None):
     """Exit with an error message."""
+    # detail is usually a multi-line string which is not suitable for normal
+    # logger.
+    if detail:
+        if isinstance(detail, dict):
+            detail = safe_dump(detail)
+        print(detail)
     LOG.critical(msg)
     sysexit(code)
 


### PR DESCRIPTION
Solves bug where there were no hint regarding which data failed to validate the schema.

As molecule validates schemas of all scenarios on load, user may be confused by
a schema validation failure if the data is not displayed.

We do print the detailed data because logging is designed to work only with
single line messages. Error comes after the detail in order to improve the user experience.

![](https://sbarnea.com/ss/Screen-Shot-2020-02-02-14-28-33.52.png)
