### PR TITLE
Made init command required opts into args

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -34,7 +34,7 @@ To generate a new role with Molecule, simply run:
 
 .. code-block:: bash
 
-    $ molecule init role -r my-new-role
+    $ molecule init role my-new-role
 
 You should then see a ``my-new-role`` folder in your current directory.
 

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -36,15 +36,15 @@ class Role(base.Base):
     """
     Init Role Command Class.
 
-    .. program:: molecule init role --role-name foo
+    .. program:: molecule init role foo
 
-    .. option:: molecule init role --role-name foo
+    .. option:: molecule init role foo
 
         Initialize a new role.
 
-    .. program:: molecule init role --role-name foo --template path
+    .. program:: molecule init role foo --template path
 
-    .. option:: molecule init role --role-name foo --template path
+    .. option:: molecule init role foo --template path
 
         Initialize a new role using ansible-galaxy and include default
         molecule directory. Please refer to the ``init scenario``
@@ -124,7 +124,7 @@ class Role(base.Base):
     default='ansible',
     help='Name of provisioner to initialize. (ansible)',
 )
-@click.option('--role-name', '-r', required=True, help='Name of the role to create.')
+@click.argument('ROLE-NAME', required=True)
 @click.option(
     '--verifier-name',
     type=click.Choice([str(s) for s in api.verifiers()]),

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -37,22 +37,22 @@ class Scenario(base.Base):
     """
     Scenario Class.
 
-    .. program:: molecule init scenario --scenario-name bar --role-name foo
+    .. program:: molecule init scenario bar --role-name foo
 
-    .. option:: molecule init scenario --scenario-name bar --role-name foo
+    .. option:: molecule init scenario bar --role-name foo
 
         Initialize a new scenario. In order to customise the role, please refer
         to the `init role` command.
 
-    .. program:: cd foo; molecule init scenario --scenario-name bar --role-name foo
+    .. program:: cd foo; molecule init scenario bar --role-name foo
 
-    .. option:: cd foo; molecule init scenario --scenario-name bar --role-name foo
+    .. option:: cd foo; molecule init scenario bar --role-name foo
 
         Initialize an existing role with Molecule:
 
-    .. program:: cd foo; molecule init scenario --scenario-name bar --role-name foo --driver-template path
+    .. program:: cd foo; molecule init scenario bar --role-name foo --driver-template path
 
-    .. option:: cd foo; molecule init scenario --scenario-name bar --role-name foo --driver-template path
+    .. option:: cd foo; molecule init scenario bar --role-name foo --driver-template path
 
         Initialize a new scenario using a local *cookiecutter* template for the
         driver configuration.
@@ -182,15 +182,11 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
     callback=_role_exists,
     help='Name of the role to create.',
 )
-@click.option(
-    '--scenario-name',
-    '-s',
+@click.argument(
+    'scenario-name',
     default=command_base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    required=True,
+    required=False,
     callback=_default_scenario_exists,
-    help='Name of the scenario to create. ({})'.format(
-        command_base.MOLECULE_DEFAULT_SCENARIO_NAME
-    ),
 )
 @click.option(
     '--verifier-name',
@@ -216,7 +212,10 @@ def scenario(
     verifier_name,
     driver_template,
 ):  # pragma: no cover
-    """Initialize a new scenario for use with Molecule."""
+    """Initialize a new scenario for use with Molecule.
+
+    If name is not specified the 'default' value will be used.
+    """
     command_args = {
         'dependency_name': dependency_name,
         'driver_name': driver_name,

--- a/molecule/test/functional/conftest.py
+++ b/molecule/test/functional/conftest.py
@@ -119,9 +119,7 @@ def idempotence(scenario_name):
 def init_role(temp_dir, driver_name):
     role_directory = os.path.join(temp_dir.strpath, 'test-init')
 
-    cmd = sh.molecule.bake(
-        'init', 'role', {'driver-name': driver_name, 'role-name': 'test-init'}
-    )
+    cmd = sh.molecule.bake('init', 'role', 'test-init', {'driver-name': driver_name})
     pytest.helpers.run_command(cmd)
     pytest.helpers.metadata_lint_update(role_directory)
 
@@ -135,9 +133,7 @@ def init_role(temp_dir, driver_name):
 def init_scenario(temp_dir, driver_name):
     # Create role
     role_directory = os.path.join(temp_dir.strpath, 'test-init')
-    cmd = sh.molecule.bake(
-        'init', 'role', {'driver-name': driver_name, 'role-name': 'test-init'}
-    )
+    cmd = sh.molecule.bake('init', 'role', 'test-init', {'driver-name': driver_name})
     pytest.helpers.run_command(cmd)
     pytest.helpers.metadata_lint_update(role_directory)
 
@@ -146,8 +142,8 @@ def init_scenario(temp_dir, driver_name):
         molecule_directory = pytest.helpers.molecule_directory()
         scenario_directory = os.path.join(molecule_directory, 'test-scenario')
 
-        options = {'scenario_name': 'test-scenario', 'role_name': 'test-init'}
-        cmd = sh.molecule.bake('init', 'scenario', **options)
+        options = {'role_name': 'test-init'}
+        cmd = sh.molecule.bake('init', 'scenario', 'test-scenario', **options)
         pytest.helpers.run_command(cmd)
 
         assert os.path.isdir(scenario_directory)

--- a/molecule/test/functional/docker/test_scenarios.py
+++ b/molecule/test/functional/docker/test_scenarios.py
@@ -73,15 +73,15 @@ def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
 
 def test_command_init_scenario_with_invalid_role_raises(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, 'test-role')
-    options = {'role_name': 'test-role'}
-    cmd = sh.molecule.bake('init', 'role', **options)
+    options = {}
+    cmd = sh.molecule.bake('init', 'role', 'test-role', **options)
     pytest.helpers.run_command(cmd)
     pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
-        options = {'scenario_name': 'default', 'role_name': 'invalid-role-name'}
+        options = {'role_name': 'invalid-role-name'}
         with pytest.raises(sh.ErrorReturnCode) as e:
-            cmd = sh.molecule.bake('init', 'scenario', **options)
+            cmd = sh.molecule.bake('init', 'scenario', 'default', **options)
             pytest.helpers.run_command(cmd, log=False)
 
         msg = (
@@ -93,8 +93,8 @@ def test_command_init_scenario_with_invalid_role_raises(temp_dir):
 
 def test_command_init_scenario_as_default_without_default_scenario(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, 'test-role')
-    options = {'role_name': 'test-role'}
-    cmd = sh.molecule.bake('init', 'role', **options)
+    options = {}
+    cmd = sh.molecule.bake('init', 'role', 'test-role', **options)
     pytest.helpers.run_command(cmd)
     pytest.helpers.metadata_lint_update(role_directory)
 
@@ -103,8 +103,8 @@ def test_command_init_scenario_as_default_without_default_scenario(temp_dir):
         scenario_directory = os.path.join(molecule_directory, 'default')
         shutil.rmtree(scenario_directory)
 
-        options = {'scenario_name': 'default', 'role_name': 'test-role'}
-        cmd = sh.molecule.bake('init', 'scenario', **options)
+        options = {'role_name': 'test-role'}
+        cmd = sh.molecule.bake('init', 'scenario', 'default', **options)
         pytest.helpers.run_command(cmd)
 
         assert os.path.isdir(scenario_directory)
@@ -114,8 +114,8 @@ def test_command_init_scenario_as_default_without_default_scenario(temp_dir):
 # a default scenario.  This tests roles not created by a newer Molecule.
 def test_command_init_scenario_without_default_scenario_raises(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, 'test-role')
-    options = {'role_name': 'test-role'}
-    cmd = sh.molecule.bake('init', 'role', **options)
+    options = {}
+    cmd = sh.molecule.bake('init', 'role', 'test-role', **options)
     pytest.helpers.run_command(cmd)
     pytest.helpers.metadata_lint_update(role_directory)
 
@@ -124,9 +124,9 @@ def test_command_init_scenario_without_default_scenario_raises(temp_dir):
         scenario_directory = os.path.join(molecule_directory, 'default')
         shutil.rmtree(scenario_directory)
 
-        options = {'scenario_name': 'invalid-role-name', 'role_name': 'test-role'}
+        options = {'role_name': 'test-role'}
         with pytest.raises(sh.ErrorReturnCode) as e:
-            cmd = sh.molecule.bake('init', 'scenario', **options)
+            cmd = sh.molecule.bake('init', 'scenario', 'invalid-role-name', **options)
             pytest.helpers.run_command(cmd, log=False)
 
         msg = (
@@ -156,8 +156,8 @@ def test_command_init_scenario_custom_template_precedence(
     temp_dir, resources_folder_path
 ):
     role_directory = os.path.join(temp_dir.strpath, 'test-role')
-    options = {'role_name': 'test-role'}
-    cmd = sh.molecule.bake('init', 'role', **options)
+    options = {}
+    cmd = sh.molecule.bake('init', 'role', 'test-role', **options)
     pytest.helpers.run_command(cmd)
     pytest.helpers.metadata_lint_update(role_directory)
 
@@ -172,13 +172,12 @@ def test_command_init_scenario_custom_template_precedence(
             resources_folder_path, 'custom_scenario_template'
         )
         options = {
-            'scenario_name': 'test-scenario',
             'role_name': 'test-role',
             'driver_template': custom_template_dir_path,
         }
 
         # command line argument takes precedence, or it would fail
-        cmd = sh.molecule.bake('init', 'scenario', **options)
+        cmd = sh.molecule.bake('init', 'scenario', 'test-scenario', **options)
         pytest.helpers.run_command(cmd, log=False)
 
 


### PR DESCRIPTION
This fix previous CLI bug which added some role name and scenario name as options instead of arguments, when they in fact were not optional.

Old: molecule init role -r foo
New molecule init role foo

Old: molecule init scenario -s bar
New: molecule init scenario bar

