### PR TITLE
Improve pytest collection failsafe

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands_pre =
     sh -c 'find {homedir}/.cache -type d -path "*/molecule_*" -exec rm -rfv \{\} +;'
 commands =
     # failsafe for preventing changes that may break pytest collection
-    sh -c "python -m pytest --collect-only >>/dev/null"
+    sh -c "PYTEST_ADDOPTS= python -m pytest -p no:cov --collect-only 2>&1 >{envlogdir}/collect.log"
     python -m pytest {posargs}
 whitelist_externals =
     find


### PR DESCRIPTION
- assures we dump result to file so we can debug
- avoid running coverage during this step
- better isolate test collection from user setup
