### PR TITLE
Move schema validation logging to debug

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -420,7 +420,7 @@ class Config(object):
 
     def _validate(self):
         msg = 'Validating schema {}.'.format(self.molecule_file)
-        LOG.info(msg)
+        LOG.debug(msg)
 
         errors = schema_v3.validate(self.config)
         if errors:
@@ -428,7 +428,7 @@ class Config(object):
             util.sysexit_with_message(msg)
 
         msg = 'Validation completed successfully.'
-        LOG.success(msg)
+        LOG.debug(msg)
 
 
 def molecule_directory(path):

--- a/molecule/test/unit/conftest.py
+++ b/molecule/test/unit/conftest.py
@@ -167,6 +167,11 @@ def patched_logger_info(mocker):
 
 
 @pytest.fixture
+def patched_logger_debug(mocker):
+    return mocker.patch('logging.Logger.debug')
+
+
+@pytest.fixture
 def patched_logger_out(mocker):
     return mocker.patch('molecule.logger.CustomLogger.out')
 

--- a/molecule/test/unit/test_config.py
+++ b/molecule/test/unit/test_config.py
@@ -310,19 +310,17 @@ def test_preflight_exists_when_validation_fails(
     patched_logger_critical.assert_called_once_with(msg)
 
 
-def test_validate(mocker, config_instance, patched_logger_info, patched_logger_success):
+def test_validate(
+    mocker, config_instance, patched_logger_debug, patched_logger_success
+):
     m = mocker.patch('molecule.model.schema_v3.validate')
     m.return_value = None
 
     config_instance._validate()
 
-    msg = 'Validating schema {}.'.format(config_instance.molecule_file)
-    patched_logger_info.assert_called_once_with(msg)
+    assert patched_logger_debug.call_count == 2
 
-    m.assert_called_once_with(config_instance.config)
-
-    msg = 'Validation completed successfully.'
-    patched_logger_success.assert_called_once_with(msg)
+    m.assert_called_with(config_instance.config)
 
 
 def test_validate_exists_when_validation_fails(


### PR DESCRIPTION
Now schema validation messages will be displayed at debug level instead of info. This should unclutter the console output.
