### PR TITLE
Makes pytest failures more verbose

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ passenv = *
 setenv =
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
     PYTHONDONTWRITEBYTECODE=1
-    _EXTRAS=--cov=molecule --no-cov-on-fail --cov-report xml:{envlogdir}/coverage.xml --html={envlogdir}/reports.html --self-contained-html
+    _EXTRAS=-l --cov=molecule --no-cov-on-fail --cov-report xml:{envlogdir}/coverage.xml --html={envlogdir}/reports.html --self-contained-html
     # -n auto used only on unit as is not supported by functional yet
     # html report is used by Zuul CI to display reports
     unit: PYTEST_ADDOPTS=molecule/test/unit/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:-n auto}


### PR DESCRIPTION
Fixed issue where test failures did not allow us to see what did not match due
to the default abbreviation. This makes output more verbose for errors, so
we can see more information.
