### PR TITLE
Fix converge to playbook rename fallback logic

### DIFF
--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -73,7 +73,7 @@ class Verify(base.Base):
         self.print_info()
         if not self._config.provisioner.playbooks.verify:
             msg = 'Skipping, verify playbook not configured.'
-            LOG.warn(msg)
+            LOG.warning(msg)
             return
         self._config.verifier.execute()
 

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -687,16 +687,7 @@ class Ansible(base.Base):
         :return: str
         """
         if playbook is None:
-            p = self.playbooks.converge
-            # TODO(ssbarnea): Remove that deprecation fallback in 3.1+
-            if os.path.basename(p) == "converge.yml" and not os.path.isfile(p):
-                old_name = os.path.join(os.path.dirname(p), "playbook.yml")
-                if os.path.isfile(old_name):
-                    LOG.warning(
-                        "playbook.yml was deprecated, rename it to converge.yml"
-                    )
-                    p = old_name
-            pb = self._get_ansible_playbook(p, **kwargs)
+            pb = self._get_ansible_playbook(self.playbooks.converge, **kwargs)
         else:
             pb = self._get_ansible_playbook(playbook, **kwargs)
 
@@ -871,6 +862,21 @@ class Ansible(base.Base):
         :param kwargs: An optional keyword arguments.
         :return: object
         """
+        if playbook:
+            # TODO(ssbarnea): Remove that deprecation fallback in 3.1+
+            pb_rename_map = {"playbook.yml": "converge.yml"}
+            basename = os.path.basename(playbook)
+            if basename in pb_rename_map and os.path.isfile(playbook):
+                LOG.warning(
+                    "%s was deprecated, rename it to %s"
+                    % (basename, pb_rename_map[basename])
+                )
+                old_name = os.path.join(
+                    os.path.dirname(playbook), pb_rename_map[basename]
+                )
+                if os.path.isfile(old_name):
+                    playbook = old_name
+
         return ansible_playbook.AnsiblePlaybook(playbook, self._config, **kwargs)
 
     def _verify_inventory(self):


### PR DESCRIPTION
Avoids failure to run check in some cases with 3.0a6

Fixes: #2541

