### PR TITLE
Assure verify step is not skipped with testinfra

### DIFF
--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -71,10 +71,6 @@ class Verify(base.Base):
         :return: None
         """
         self.print_info()
-        if not self._config.provisioner.playbooks.verify:
-            msg = 'Skipping, verify playbook not configured.'
-            LOG.warning(msg)
-            return
         self._config.verifier.execute()
 
 

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -751,6 +751,10 @@ class Ansible(base.Base):
 
         :return: None
         """
+        if not self.playbooks.verify:
+            LOG.warning('Skipping, verify playbook not configured.')
+            return
+
         pb = self._get_ansible_playbook(self.playbooks.verify)
         pb.execute()
 

--- a/molecule/test/unit/provisioner/test_ansible.py
+++ b/molecule/test/unit/provisioner/test_ansible.py
@@ -584,10 +584,11 @@ def test_syntax(_instance, mocker, _patched_ansible_playbook):
 def test_verify(_instance, mocker, _patched_ansible_playbook):
     _instance.verify()
 
-    _patched_ansible_playbook.assert_called_once_with(
-        _instance._config.provisioner.playbooks.verify, _instance._config
-    )
-    _patched_ansible_playbook.return_value.execute.assert_called_once_with()
+    if _instance._config.provisioner.playbooks.verify:
+        _patched_ansible_playbook.assert_called_once_with(
+            _instance._config.provisioner.playbooks.verify, _instance._config
+        )
+        _patched_ansible_playbook.return_value.execute.assert_called_once_with()
 
 
 def test_write_config(temp_dir, _instance):

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,6 +119,7 @@ test =
     pytest-xdist>=1.29.0, < 2
     pytest>=4.6.3, < 5
     shade>=1.31.0, < 2
+    testinfra >= 3.4.0
 lint =
     ansible-lint >= 4.1.1a2, < 5
     flake8 >= 3.6.0


### PR DESCRIPTION
Fixed regression in previous pre-release cased by the switch from having ansible the default verifier instead of testinfra. Ansible verifier behavior is to skip verify step when playbook is missing, but with testinfra skip should not happen because the tests are not a playbook.

Fixes: #2543
