### PR TITLE
Mention container_default_behavior value

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -148,6 +148,7 @@
         restart_retries: "{{ item.restart_retries | default(omit) }}"
         tty: "{{ item.tty | default(omit) }}"
         labels: "{{ item.labels | default(omit) }}"
+        container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       loop_control:

--- a/molecule/provisioner/ansible/playbooks/docker/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/destroy.yml
@@ -16,6 +16,7 @@
         state: absent
         force_kill: "{{ item.force_kill | default(true) }}"
         keep_volumes: "{{ item.keep_volumes | default(true) }}"
+        container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       loop_control:

--- a/molecule/test/resources/playbooks/delegated/create/docker.yml
+++ b/molecule/test/resources/playbooks/delegated/create/docker.yml
@@ -11,3 +11,4 @@
     networks: "{{ item.networks | default(omit) }}"
     dns_servers: "{{ item.dns_servers | default(omit) }}"
     networks_cli_compatible: "{{ item.networks_cli_compatible | default(true) }}"
+    container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"

--- a/molecule/test/resources/playbooks/delegated/destroy/docker.yml
+++ b/molecule/test/resources/playbooks/delegated/destroy/docker.yml
@@ -3,3 +3,4 @@
   docker_container:
     name: delegated-instance-docker
     state: absent
+    container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"

--- a/molecule/test/resources/playbooks/docker/create.yml
+++ b/molecule/test/resources/playbooks/docker/create.yml
@@ -124,6 +124,7 @@
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"
         restart_retries: "{{ item.restart_retries | default(omit) }}"
+        container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/molecule/test/resources/playbooks/docker/destroy.yml
+++ b/molecule/test/resources/playbooks/docker/destroy.yml
@@ -16,6 +16,7 @@
         state: absent
         force_kill: "{{ item.force_kill | default(true) }}"
         keep_volumes: "{{ item.keep_volumes | default(true) }}"
+        container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200


### PR DESCRIPTION
Avoids runtime deprecation warnings with ansible 2.10+ caused by
missing container_default_behavior option.
