### PR TITLE
Avoid breaking pytest collection with testinfra

### DIFF
--- a/molecule/cookiecutter/scenario/verifier/testinfra/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/conftest.py
+++ b/molecule/cookiecutter/scenario/verifier/testinfra/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/conftest.py
@@ -1,0 +1,20 @@
+"""PyTest Fixtures."""
+from __future__ import absolute_import
+import os
+import pytest
+
+
+def pytest_runtest_setup(item):
+    """Run tests only when under molecule with testinfra installed."""
+    try:
+        import testinfra
+    except ImportError:
+        pytest.skip("Test requires testinfra", allow_module_level=True)
+    if 'MOLECULE_INVENTORY_FILE' in os.environ:
+        pytest.testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+            os.environ['MOLECULE_INVENTORY_FILE']
+        ).get_hosts('all')
+    else:
+        pytest.skip(
+            "Test should run only from inside molecule.", allow_module_level=True
+        )

--- a/molecule/cookiecutter/scenario/verifier/testinfra/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.py
+++ b/molecule/cookiecutter/scenario/verifier/testinfra/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.py
@@ -1,11 +1,4 @@
 """Role testing files using testinfra."""
-import os
-
-import testinfra.utils.ansible_runner
-
-testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']
-).get_hosts('all')
 
 
 def test_hosts_file(host):


### PR DESCRIPTION
Updates testinfra cookiecutter template with code that skips the tests
when run outside molecule or when testinfra is not installed.

This would prevent breaking other usages of pytest, including collection,
when creating a new role inside a repository that already had tests.

Fixes: #2528
