### PR TITLE
Remove scenario name from molecule.yml

### DIFF
--- a/molecule/model/schema_v3.py
+++ b/molecule/model/schema_v3.py
@@ -92,10 +92,7 @@ def pre_validate_base_schema(env, keep_string):
                 },
             },
         },
-        'scenario': {
-            'type': 'dict',
-            'schema': {'name': {'type': 'string', 'molecule_env_var': True}},
-        },
+        'scenario': {'type': 'dict', 'schema': {'name': {'molecule_env_var': True}}},
         'verifier': {
             'type': 'dict',
             'schema': {
@@ -210,7 +207,6 @@ base_schema = {
     'scenario': {
         'type': 'dict',
         'schema': {
-            'name': {'type': 'string'},
             'check_sequence': {'type': 'list', 'schema': {'type': 'string'}},
             'converge_sequence': {'type': 'list', 'schema': {'type': 'string'}},
             'create_sequence': {'type': 'list', 'schema': {'type': 'string'}},

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -52,7 +52,6 @@ class Scenario(object):
     .. code-block:: yaml
 
         scenario:
-          name: default  # optional
           create_sequence:
             - dependency
             - create

--- a/molecule/test/functional/test_command.py
+++ b/molecule/test/functional/test_command.py
@@ -202,8 +202,11 @@ def test_command_init_role(temp_dir, driver_name, skip_test):
     pytest.helpers.init_role(temp_dir, driver_name)
 
 
-def test_command_init_scenario(temp_dir, skip_test):
-    pytest.helpers.init_scenario(temp_dir, "delegated")
+@pytest.mark.parametrize(
+    'driver_name', [('docker'), ('podman')], indirect=['driver_name']
+)
+def test_command_init_scenario(temp_dir, driver_name, skip_test):
+    pytest.helpers.init_scenario(temp_dir, driver_name)
 
 
 @pytest.mark.parametrize(

--- a/molecule/test/functional/test_command.py
+++ b/molecule/test/functional/test_command.py
@@ -202,11 +202,8 @@ def test_command_init_role(temp_dir, driver_name, skip_test):
     pytest.helpers.init_role(temp_dir, driver_name)
 
 
-@pytest.mark.parametrize(
-    'driver_name', [('docker'), ('podman')], indirect=['driver_name']
-)
-def test_command_init_scenario(temp_dir, driver_name, skip_test):
-    pytest.helpers.init_scenario(temp_dir, driver_name)
+def test_command_init_scenario(temp_dir, skip_test):
+    pytest.helpers.init_scenario(temp_dir, "delegated")
 
 
 @pytest.mark.parametrize(

--- a/molecule/test/scenarios/cleanup/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/cleanup/molecule/default/molecule.yml
@@ -17,7 +17,5 @@ provisioner:
     create: ../../../../resources/playbooks/docker/create.yml
     destroy: ../../../../resources/playbooks/docker/destroy.yml
     cleanup: cleanup.yml
-scenario:
-  name: default
 verifier:
   name: ansible

--- a/molecule/test/scenarios/driver/delegated/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/delegated/molecule/default/molecule.yml
@@ -11,8 +11,6 @@ provisioner:
         hosts:
           instance:
             ansible_host: localhost
-scenario:
-  name: default
   default_sequence:
     - converge
   test_sequence:

--- a/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
@@ -22,7 +22,5 @@ provisioner:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
     # keep this here to test that we convert integers to strings:
     SOME_VALUE_AS_INFO: 1
-scenario:
-  name: default
 verifier:
   name: ansible

--- a/molecule/test/scenarios/driver/podman/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/podman/molecule/default/molecule.yml
@@ -22,7 +22,5 @@ provisioner:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
     # keep this here to test that we convert integers to strings:
     SOME_VALUE_AS_INFO: 1
-scenario:
-  name: default
 verifier:
   name: ansible

--- a/molecule/test/scenarios/host_group_vars/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/host_group_vars/molecule/default/molecule.yml
@@ -33,7 +33,5 @@ provisioner:
         host_group_vars_example_group_two_molecule_yml: true
       example_1:
         host_group_vars_example_1_child_group_molecule_yml: true
-scenario:
-  name: default
 verifier:
   name: ansible

--- a/molecule/test/scenarios/interpolation/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/interpolation/molecule/default/molecule.yml
@@ -14,7 +14,5 @@ provisioner:
   playbooks:
     create: ../../../../resources/playbooks/docker/create.yml
     destroy: ../../../../resources/playbooks/docker/destroy.yml
-scenario:
-  name: default
 verifier:
   name: ansible

--- a/molecule/test/scenarios/overrride_driver/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/overrride_driver/molecule/default/molecule.yml
@@ -15,7 +15,5 @@ provisioner:
     docker:
       create: ../../../../resources/playbooks/docker/create.yml
       destroy: ../../../../resources/playbooks/docker/destroy.yml
-scenario:
-  name: default
 verifier:
   name: ansible

--- a/molecule/test/scenarios/plugins/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/plugins/molecule/default/molecule.yml
@@ -16,7 +16,5 @@ provisioner:
     destroy: ../../../../resources/playbooks/docker/destroy.yml
   env:
     ANSIBLE_ROLES_PATH: ../../../../resources/roles/
-scenario:
-  name: default
 verifier:
   name: ansible

--- a/molecule/test/scenarios/side_effect/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/side_effect/molecule/default/molecule.yml
@@ -17,7 +17,5 @@ provisioner:
     create: ../../../../resources/playbooks/docker/create.yml
     destroy: ../../../../resources/playbooks/docker/destroy.yml
     side_effect: side_effect.yml
-scenario:
-  name: default
 verifier:
   name: ansible

--- a/molecule/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
@@ -14,7 +14,5 @@ provisioner:
   playbooks:
     create: ../../../../resources/playbooks/docker/create.yml
     destroy: ../../../../resources/playbooks/docker/destroy.yml
-scenario:
-  name: default
 verifier:
   name: ansible

--- a/molecule/test/unit/model/v2/test_pre_validate.py
+++ b/molecule/test/unit/model/v2/test_pre_validate.py
@@ -107,8 +107,6 @@ platforms:
       - name: bar
 provisioner:
   name: $MOLECULE_PROVISIONER_NAME
-scenario:
-  name: $MOLECULE_SCENARIO_NAME
 verifier:
   name: $MOLECULE_VERIFIER_NAME
 """.strip()
@@ -118,9 +116,6 @@ def test_has_errors_when_molecule_env_var_referenced_in_unallowed_sections(
     _model_molecule_env_errors_section_data, _env, _keep_string
 ):
     x = {
-        'scenario': [
-            {'name': ['cannot reference $MOLECULE special variables in this section']}
-        ],
         'driver': [
             {
                 'name': [

--- a/molecule/test/unit/model/v2/test_scenario_section.py
+++ b/molecule/test/unit/model/v2/test_scenario_section.py
@@ -64,7 +64,6 @@ def test_scenario_has_errors(_config):
         'scenario': [
             {
                 'converge_sequence': [{0: ['must be of string type']}],
-                'name': ['must be of string type'],
                 'check_sequence': [{0: ['must be of string type']}],
                 'create_sequence': [{0: ['must be of string type']}],
                 'destroy_sequence': [{0: ['must be of string type']}],

--- a/molecule/test/unit/test_interpolation.py
+++ b/molecule/test/unit/test_interpolation.py
@@ -98,8 +98,6 @@ platforms:
   - name: instance-1
 provisioner:
     name: ansible
-scenario:
-    name: $MOLECULE_SCENARIO_NAME
 verifier:
     name: ${VERIFIER_NAME}
     options:
@@ -116,8 +114,6 @@ platforms:
   - name: instance-1
 provisioner:
     name: ansible
-scenario:
-    name: default
 verifier:
     name: ansible
     options:


### PR DESCRIPTION
Scenario name is now always the folder name containing the molecule.yml and
can no longer be configured in-file.

Remove scenario.name from v2 configuration files to avoid getting an error.

This will allow us to refactor molecule, making it faster and not
forcing it to parse all scenarios in order to later run only one.

Fixes: #2434