### PR TITLE
Update instruction with correct flag

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -34,7 +34,7 @@ To generate a new role with Molecule, simply run:
 
 .. code-block:: bash
 
-    $ molecule init role my-new-role
+    $ molecule init role --role-name my-new-role
 
 You should then see a ``my-new-role`` folder in your current directory.
 


### PR DESCRIPTION
Minor fix for https://molecule.readthedocs.io/en/latest/getting-started.html with incorrect information when init a new role dir
Old: $ molecule init role my-new-role
Should be: $ molecule init role --role-name my-new-role


- Docs Pull Request

