### PR TITLE
Load molecule config from VCS if possible

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -1,0 +1,1 @@
+# This is loaded by default

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -19,8 +19,6 @@
 #  DEALINGS IN THE SOFTWARE.
 """Molecule Shell Module."""
 
-import os
-
 import click
 import click_completion
 import colorama
@@ -33,13 +31,16 @@ import molecule
 from molecule import command
 from molecule.config import MOLECULE_DEBUG
 from molecule.logger import should_do_markup
+from molecule.util import lookup_config_file
 from molecule.command.base import click_group_ex
 from click_help_colors import _colorize
 
 click_completion.init()
 colorama.init(autoreset=True, strip=not should_do_markup())
 
-LOCAL_CONFIG = os.path.expanduser('~/.config/molecule/config.yml')
+LOCAL_CONFIG = lookup_config_file('.config/molecule/config.yml')
+
+
 ENV_FILE = '.env.yml'
 
 
@@ -71,9 +72,10 @@ def _version_string():
     '-c',
     default=LOCAL_CONFIG,
     help=(
-        'Path to a base config.  If provided Molecule will load '
+        "Path to a base config.  If provided Molecule will load "
         "this config first, and deep merge each scenario's "
-        'molecule.yml on top. ({})'
+        "molecule.yml on top. By default is looking for config in current "
+        "VCS repository and if not found it will look on user home. ({})"
     ).format(LOCAL_CONFIG),
 )
 @click.option(

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -357,3 +357,23 @@ def _parallelize_platforms(config, run_uuid):
         return platform
 
     return [parallelize(platform) for platform in config['platforms']]
+
+
+def find_vcs_root(test, dirs=(".git", ".hg", ".svn"), default=None):
+    """Return current repository root directory."""
+    prev, test = None, os.path.abspath(test)
+    while prev != test:
+        if any(os.path.isdir(os.path.join(test, d)) for d in dirs):
+            return test
+        prev, test = test, os.path.abspath(os.path.join(test, os.pardir))
+    return default
+
+
+def lookup_config_file(filename):
+    """Return config file PATH."""
+    for path in [find_vcs_root(os.getcwd(), default='~'), '~']:
+        f = os.path.expanduser('%s/%s' % (path, filename))
+        if os.path.isfile(f):
+            LOG.info("Found config file %s", f)
+            return f
+    return f


### PR DESCRIPTION
Instead of looking for config file only in user home, molecule will
now also look in current VCS repository.

This will enable people to add configs that are repository wide.

Due to its special naming `.config/molecule/config.yml`, there are
no real risks of breaking user configs.

Partial-Fix: #2565