### PR TITLE
Suggest using python3 and pip3 in example docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,10 @@ RUN apk add --update --no-cache --repository http://dl-3.alpinelinux.org/alpine/
 ENV MOLECULE_EXTRAS="docker,docs,windows,lint"
 
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=917006
-RUN pip3 install -U wheel
+RUN python3 -m pip install -U wheel
 ADD . .
 RUN \
-    pip3 wheel \
+    python3 -m pip wheel \
     -w dist --no-build-isolation \
     ".[${MOLECULE_EXTRAS}]" testinfra
 RUN ls -1 dist/
@@ -143,7 +143,7 @@ COPY --from=molecule-builder \
     /usr/src/molecule/dist \
     /usr/src/molecule/dist
 RUN \
-    pip3 install \
+    python3 -m pip install \
     ${PIP_INSTALL_ARGS} \
     "molecule[${MOLECULE_EXTRAS}]" testinfra
 

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ If you want to get moving fast and make a quick patch:
 
     $ git clone https://github.com/ansible-community/molecule && cd molecule
     $ python3 -m venv .venv && source .venv/bin/activate
-    $ pip install -U setuptools pip tox
+    $ pip3 install -U setuptools pip tox
 
 And you're ready to make your changes!
 

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ If you want to get moving fast and make a quick patch:
 
     $ git clone https://github.com/ansible-community/molecule && cd molecule
     $ python3 -m venv .venv && source .venv/bin/activate
-    $ pip3 install -U setuptools pip tox
+    $ python3 -m pip install -U setuptools pip tox
 
 And you're ready to make your changes!
 

--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -40,7 +40,7 @@ and run ``molecule test`` in ubuntu.
           run: |
             sudo apt install docker
             python3 -m pip install --upgrade pip
-            pip3 install -r requirements.txt
+            python3 -m pip install -r requirements.txt
         - name: Test with molecule
           run: |
             molecule test
@@ -62,8 +62,8 @@ A ``.travis.yml`` testing a role named foo1 with the Docker driver.
     before_install:
       - sudo apt-get -qq update
     install:
-      - pip3 install molecule
-      # - pip3 install required driver (e.g. docker, shade, boto, apache-libcloud)
+      - python3 -m pip install molecule
+      # - python3 -m pip install required driver (e.g. docker, shade, boto, apache-libcloud)
     script:
       - molecule test
 
@@ -79,7 +79,7 @@ A ``.travis.yml`` using `Tox`_ as described below.
     before_install:
       - sudo apt-get -qq update
     install:
-      - pip3 install tox-travis
+      - python3 -m pip install tox-travis
     script:
       - tox
 
@@ -110,7 +110,7 @@ Here is an example setting up a virtualenv and testing an Ansible role via Molec
     molecule:
     stage: test
     script:
-      - pip3 install ansible molecule docker
+      - python3 -m pip install ansible molecule docker
       - ansible --version
       - cd roles/testrole && molecule test
 
@@ -149,7 +149,7 @@ Jenkins Pipeline
               pip3.6 install virtualenv
               virtualenv virtenv
               source virtenv/bin/activate
-              pip3 install --upgrade ansible molecule docker
+              python3 -m pip install --upgrade ansible molecule docker
             '''
           }
         }

--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -39,8 +39,8 @@ and run ``molecule test`` in ubuntu.
         - name: Install dependencies
           run: |
             sudo apt install docker
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt
+            python3 -m pip install --upgrade pip
+            pip3 install -r requirements.txt
         - name: Test with molecule
           run: |
             molecule test
@@ -62,8 +62,8 @@ A ``.travis.yml`` testing a role named foo1 with the Docker driver.
     before_install:
       - sudo apt-get -qq update
     install:
-      - pip install molecule
-      # - pip install required driver (e.g. docker, shade, boto, apache-libcloud)
+      - pip3 install molecule
+      # - pip3 install required driver (e.g. docker, shade, boto, apache-libcloud)
     script:
       - molecule test
 
@@ -79,7 +79,7 @@ A ``.travis.yml`` using `Tox`_ as described below.
     before_install:
       - sudo apt-get -qq update
     install:
-      - pip install tox-travis
+      - pip3 install tox-travis
     script:
       - tox
 
@@ -149,7 +149,7 @@ Jenkins Pipeline
               pip3.6 install virtualenv
               virtualenv virtenv
               source virtenv/bin/activate
-              pip install --upgrade ansible molecule docker
+              pip3 install --upgrade ansible molecule docker
             '''
           }
         }

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,7 @@ CentOS 7
 .. code-block:: bash
 
     $ sudo yum install -y epel-release
-    $ sudo yum install -y gcc python-pip python-devel openssl-devel libselinux-python
+    $ sudo yum install -y gcc python3-pip python3-devel openssl-devel libselinux-python
 
 Ubuntu 16.x
 -----------
@@ -30,7 +30,7 @@ Ubuntu 16.x
 .. code-block:: bash
 
     $ sudo apt-get update
-    $ sudo apt-get install -y python-pip libssl-dev
+    $ sudo apt-get install -y python3-pip libssl-dev
 
 Pip
 ===
@@ -54,7 +54,7 @@ available on your controller or host machines.
 
   .. code-block:: bash
 
-      $ pip install --upgrade --user setuptools
+      $ pip3 install --upgrade --user setuptools
 
   .. _setuptools: https://pypi.org/project/setuptools/
 
@@ -79,7 +79,7 @@ Install Molecule:
 
 .. code-block:: bash
 
-    $ pip install --user "molecule[lint]"
+    $ pip3 install --user "molecule[lint]"
 
 Installing molecule package also installed its main script ``molecule``,
 usually in ``PATH``. Users should know that molecule can also be called as a
@@ -98,7 +98,7 @@ some benefits:
 
     .. code-block:: bash
 
-        pip install \
+        pip3 install \
           --index-url https://test.pypi.org/simple \
           --extra-index-url https://pypi.org/simple \
           molecule==2.21.dev46
@@ -173,4 +173,4 @@ Install
 
 .. code-block:: bash
 
-    $ pip install -U git+https://github.com/ansible-community/molecule
+    $ pip3 install -U git+https://github.com/ansible-community/molecule

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -54,7 +54,7 @@ available on your controller or host machines.
 
   .. code-block:: bash
 
-      $ pip3 install --upgrade --user setuptools
+      $ python3 -m pip install --upgrade --user setuptools
 
   .. _setuptools: https://pypi.org/project/setuptools/
 
@@ -79,7 +79,7 @@ Install Molecule:
 
 .. code-block:: bash
 
-    $ pip3 install --user "molecule[lint]"
+    $ python3 -m pip install --user "molecule[lint]"
 
 Installing molecule package also installed its main script ``molecule``,
 usually in ``PATH``. Users should know that molecule can also be called as a
@@ -98,7 +98,7 @@ some benefits:
 
     .. code-block:: bash
 
-        pip3 install \
+        python3 -m pip install \
           --index-url https://test.pypi.org/simple \
           --extra-index-url https://pypi.org/simple \
           molecule==2.21.dev46
@@ -173,4 +173,4 @@ Install
 
 .. code-block:: bash
 
-    $ pip3 install -U git+https://github.com/ansible-community/molecule
+    $ python3 -m pip install -U git+https://github.com/ansible-community/molecule

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -16,7 +16,7 @@ Install the test framework `Tox`_.
 
 .. code-block:: bash
 
-    $ pip install tox
+    $ pip3 install tox
 
 .. _full_testing:
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -16,7 +16,7 @@ Install the test framework `Tox`_.
 
 .. code-block:: bash
 
-    $ pip3 install tox
+    $ python3 -m pip install tox
 
 .. _full_testing:
 

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -35,7 +35,7 @@ class Lint(base.Base):
 
     You need to remember to install those linters. For convenience, there is a
     package extra that installs the most common ones, use it like
-    ``pip3 install "molecule[lint]"``.
+    ``python3 -m pip install "molecule[lint]"``.
 
     .. program:: molecule lint
 

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -35,7 +35,7 @@ class Lint(base.Base):
 
     You need to remember to install those linters. For convenience, there is a
     package extra that installs the most common ones, use it like
-    ``pip install "molecule[lint]"``.
+    ``pip3 install "molecule[lint]"``.
 
     .. program:: molecule lint
 

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -19,4 +19,4 @@ widely recommended `'--user' flag`_ when invoking ``pip``.
 
 .. code-block:: bash
 
-    $ pip install 'molecule[docker]'
+    $ pip3 install 'molecule[docker]'

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -19,4 +19,4 @@ widely recommended `'--user' flag`_ when invoking ``pip``.
 
 .. code-block:: bash
 
-    $ pip3 install 'molecule[docker]'
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -19,4 +19,4 @@ widely recommended `'--user' flag`_ when invoking ``pip``.
 
 .. code-block:: bash
 
-    $ pip install 'molecule[podman]'
+    $ pip3 install 'molecule[podman]'

--- a/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -19,4 +19,4 @@ widely recommended `'--user' flag`_ when invoking ``pip``.
 
 .. code-block:: bash
 
-    $ pip3 install 'molecule[podman]'
+    $ python3 -m pip install 'molecule[podman]'

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -147,7 +147,7 @@ class Docker(Driver):
 
     .. code-block:: bash
 
-        $ pip3 install molecule[docker]
+        $ python3 -m pip install molecule[docker]
 
     When pulling from a private registry, it is the user's discretion to decide
     whether to use hard-code strings or environment variables for passing

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -147,7 +147,7 @@ class Docker(Driver):
 
     .. code-block:: bash
 
-        $ pip install molecule[docker]
+        $ pip3 install molecule[docker]
 
     When pulling from a private registry, it is the user's discretion to decide
     whether to use hard-code strings or environment variables for passing

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -117,7 +117,7 @@ class Podman(Driver):
 
     .. code-block:: bash
 
-        $ pip3 install molecule[podman]
+        $ python3 -m pip install molecule[podman]
 
     When pulling from a private registry, it is the user's discretion to decide
     whether to use hard-code strings or environment variables for passing

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -117,7 +117,7 @@ class Podman(Driver):
 
     .. code-block:: bash
 
-        $ pip install molecule[podman]
+        $ pip3 install molecule[podman]
 
     When pulling from a private registry, it is the user's discretion to decide
     whether to use hard-code strings or environment variables for passing


### PR DESCRIPTION
Some common distros do not alias "pip" and "python" to Python 3 versions. This will encourage users following the examples to install and run Molecule with Python 3.

This does not change the actual support status of Python 2.

#### PR Type
- Docs Pull Request