### PR TITLE
Install rsync in Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ ENV PACKAGES="\
     ansible \
     ansible-lint \
     docker-py \
+    rsync \
     py3-arrow \
     py3-bcrypt \
     py3-botocore \


### PR DESCRIPTION
#### PR Type

- Bugfix Pull Request

This PR fixes #2583 by installing rsync in the molecule Docker Image.