### PR TITLE
Fix dependency on pre-commit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,6 @@ install_requires =
     pathlib2; python_version<"3.2"
     pexpect >= 4.6.0, < 5
     pluggy >= 0.7.1, < 1.0
-    pre-commit >= 1.17.0, < 2
     PyYAML >= 5.1, < 6
     sh >= 1.12.14
     six >= 1.11.0
@@ -123,7 +122,8 @@ test =
 lint =
     ansible-lint >= 4.1.1a2, < 5
     flake8 >= 3.6.0
-    pre-commit >= 1.17.0
+    pre-commit >= 1.21.0, < 2; python_version<"3.5"
+    pre-commit >= 1.21.0; python_version>="3.5"
     yamllint >= 1.15.0
 
 [options.entry_points]


### PR DESCRIPTION
- avoids runtime error with pre-commit v2
- removes pre-commit from molecule main dependencies
- assures we install old pre-commit on old python versions
