### PR TITLE
Add snapcraft.io config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info/
 *.py[cod]
 *.retry
+*.snap
 .bundle/
 .cache/
 .coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,7 @@ ENV PACKAGES="\
     py3-paramiko \
     py3-pbr \
     py3-pexpect \
+    py3-pip \
     py3-pluggy \
     py3-psutil \
     py3-ptyprocess \

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,11 +1,10 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
-gcc-c++ [test platform:rpm]
 gcc [test platform:rpm]
+gcc-c++ [test platform:rpm]
 libselinux-python [platform:centos-7]
-python36 [test !platform:centos-7 !platform:fedora-28]
-python3-devel [test !platform:centos-7 platform:rpm]
-python3-libselinux [platform:fedora]
+python3 [test platform:rpm !platform:centos-7]
+python3-devel [test platform:rpm !platform:centos-7]
+python3-libselinux [test platform:rpm !platform:centos-7]
 python3-netifaces [test !platform:centos-7 platform:rpm]
-python3 [test !platform:centos-7 platform:rpm]

--- a/playbooks/snap-pre-run.yaml
+++ b/playbooks/snap-pre-run.yaml
@@ -1,0 +1,36 @@
+- hosts: all
+  become: true
+  tasks:
+
+    - name: Install snapd
+      package:
+        name: snapd
+        state: present
+
+    - name: Enable snapd service
+      service:
+        name: snapd.socket
+        state: started
+
+    - when: ansible_os_family == 'Debian'
+      name: Install snapcraft (debian)
+      package:
+        name: snapcraft
+        state: present
+
+    - when: ansible_os_family == 'RedHat'
+      block:
+
+        - name: Activate snapd
+          shell: |
+            ln -s /var/lib/snapd/snap /snap
+
+        - name: Install snapcraft (redhat)
+          shell: |
+            type snapcraft || snap install --classic snapcraft
+
+    - name: Validate snapd install
+      shell: |
+        set -e
+        snap version
+        snapcraft version

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ project_urls =
     Source Code = https://github.com/ansible-community/molecule
 description = Molecule aids in the development and testing of Ansible roles
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 author = Ansible by Red Hat
 author_email = info@ansible.com
 maintainer = Ansible by Red Hat

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: molecule
+base: core18  # the base snap is the execution environment for this snap
+version: git
+summary: Ansible Molecule
+description: |
+  Molecule is QA tool use for the development and testing of Ansible roles
+  and playbooks.
+
+grade: devel  # must be 'stable' to release into candidate/stable channels
+confinement: devmode  # use 'strict' once you have the right plugs and slots
+
+parts:
+  molecule:
+    # See 'snapcraft plugins'
+    plugin: python
+    python-packages:
+      - setuptools-scm
+      - setuptools-scm-git-archive
+    source: .

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ commands =
     python -m pytest {posargs}
 whitelist_externals =
     find
+    rm
     sh
 
 [testenv:lint]
@@ -143,5 +144,11 @@ commands =
       --out-dir {toxinidir}/dist/ \
       {toxinidir}
     # metadata validation
-    python -m setup checkdocs check --metadata --restructuredtext --strict --verbose
     python -m twine check .tox/dist/*
+
+[testenv:snap]
+description = Builds a snap package
+usedevelop = false
+skip_install = true
+commands =
+    sh -c "type snapcraft && snapcraft build"

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -37,6 +37,15 @@
     vars:
       tox_envlist: packaging
 
+- job:
+    name: molecule-tox-snap
+    description: Runs tests related to building a snap
+    parent: ansible-tox-molecule
+    pre-run: playbooks/snap-pre-run.yaml
+    nodeset: ubuntu-bionic-1vcpu
+    vars:
+      tox_envlist: snap
+
 # jobs specific to molecule itself
 - job:
     name: molecule-tox-py27-ansible28-unit
@@ -178,31 +187,33 @@
     templates:
       - publish-to-pypi
     check:
-      jobs: &defaults
+      jobs: &jobs
+        - molecule-tox-docs
         - molecule-tox-linters:
             vars:
               tox_envlist: lint
-        - molecule-tox-docs
         - molecule-tox-packaging:
             vars:
               tox_envlist: packaging,dockerfile,build-docker
+        - molecule-tox-devel-unit
         - molecule-tox-py27-ansible28-unit
         - molecule-tox-py27-ansible29-unit
         - molecule-tox-py36-ansible29-unit
         - molecule-tox-py37-ansible28-unit
         - molecule-tox-py37-ansible29-unit
-        - molecule-tox-devel-unit
+        - molecule-tox-snap
         # tier2: slow functional
         - molecule-tox-py27-ansible28-functional: &deps
             dependencies:
-              - molecule-tox-linters
+              - molecule-tox-devel-unit
               - molecule-tox-docs
+              - molecule-tox-linters
               - molecule-tox-py27-ansible28-unit
               - molecule-tox-py27-ansible29-unit
               - molecule-tox-py36-ansible29-unit
               - molecule-tox-py37-ansible28-unit
               - molecule-tox-py37-ansible29-unit
-              - molecule-tox-devel-unit
+              - molecule-tox-snap
         - molecule-tox-py27-ansible29-functional: *deps
         - molecule-tox-py36-ansible29-functional: *deps
         - molecule-tox-py37-ansible28-functional: *deps
@@ -210,23 +221,4 @@
         - molecule-tox-devel-functional: *deps
 
     gate:
-      jobs:
-        - molecule-tox-linters:
-            vars:
-              tox_envlist: lint
-        - molecule-tox-docs
-        - molecule-tox-packaging:
-            vars:
-              tox_envlist: packaging,dockerfile,build-docker
-        - molecule-tox-py27-ansible28-unit
-        - molecule-tox-py27-ansible29-unit
-        - molecule-tox-py36-ansible29-unit
-        - molecule-tox-py37-ansible28-unit
-        - molecule-tox-py37-ansible29-unit
-        - molecule-tox-devel-unit
-        - molecule-tox-py27-ansible28-functional
-        - molecule-tox-py27-ansible29-functional
-        - molecule-tox-py36-ansible29-functional
-        - molecule-tox-py37-ansible28-functional
-        - molecule-tox-py37-ansible29-functional
-        - molecule-tox-devel-functional
+      jobs: *jobs


### PR DESCRIPTION
This should allow to publish molecule as a snap as snaps can easily be installed on:

* debian platfroms (ubuntu)
* centos/fedora - via snapd from epel
* [macos using brew](https://snapcraft.io/docs/install-snapcraft-on-macos)

