### PR TITLE
Add missing spaces in gitlab-ci example

### DIFF
--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -108,11 +108,11 @@ Here is an example setting up a virtualenv and testing an Ansible role via Molec
       - python3 --version
 
     molecule:
-    stage: test
-    script:
-      - python3 -m pip install ansible molecule docker
-      - ansible --version
-      - cd roles/testrole && molecule test
+      stage: test
+      script:
+        - python3 -m pip install ansible molecule docker
+        - ansible --version
+        - cd roles/testrole && molecule test
 
 Jenkins Pipeline
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Please include details of what it is, how to use it, how it's been tested
Please include an entry in the CHANGELOG.md if the change will impact users.

#### PR Type

- Docs Pull Request

Details: 
Gitlab-ci example ( at https://molecule.readthedocs.io/en/latest/ci.html#gitlab-ci ) is missing indentation.
