### PR TITLE
Fix a missing ":" before the reference to "galaxy".

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -97,7 +97,7 @@ The ``molecule.yml`` is for configuring Molecule. It is a `YAML`_ file whose
 keys represent the high level components that Molecule provides. These are:
 
 * The :ref:`dependency` manager. Molecule uses
-  std:doc:`galaxy <galaxy/dev_guide>` by default to resolve your role
+  :std:doc:`galaxy <galaxy/dev_guide>` by default to resolve your role
   dependencies.
 
 * The :ref:`driver` provider. Molecule uses `Docker`_ by default. Molecule uses


### PR DESCRIPTION
#### PR Type

- Docs Pull Request

#### Description

This PR fixes a broken link we can see in this doc: [Getting Started Guide — Molecule 3.0.3.dev26+g54df13b0 documentation](https://molecule.readthedocs.io/en/latest/getting-started.html#inspecting-the-molecule-yml). A missing `:` causes this error.
