### PR TITLE
Increase timeout on molecule-tox-packaging

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -34,6 +34,7 @@
     name: molecule-tox-packaging
     description: Runs tests related to packaging
     parent: ansible-tox-molecule
+    timeout: 3600
     vars:
       tox_envlist: packaging
 


### PR DESCRIPTION
Packaging can take a lot of time when it tries to verify packaging on lots of containerized platforms.