### PR TITLE
Add support for memory and kernel_memory module parameters

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -121,7 +121,6 @@
         hostname: "{{ item.hostname | default(item.name) }}"
         image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         pull: "{{ item.pull | default(omit) }}"
-        kernel_memory: "{{ item.kernel_memory | default(omit) }}"
         memory: "{{ item.memory | default(omit) }}"
         state: started
         recreate: false

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -121,6 +121,8 @@
         hostname: "{{ item.hostname | default(item.name) }}"
         image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         pull: "{{ item.pull | default(omit) }}"
+        kernel_memory: "{{ item.kernel_memory | default(omit) }}"
+        memory: "{{ item.memory | default(omit) }}"
         state: started
         recreate: false
         log_driver: json-file

--- a/molecule/test/resources/playbooks/docker/create.yml
+++ b/molecule/test/resources/playbooks/docker/create.yml
@@ -101,7 +101,6 @@
         hostname: "{{ item.hostname | default(item.name) }}"
         image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         pull: "{{ item.pull | default (omit) }}"
-        kernel_memory: "{{ item.kernel_memory | default(omit) }}"
         memory: "{{ item.memory | default(omit) }}"
         state: started
         recreate: false

--- a/molecule/test/resources/playbooks/docker/create.yml
+++ b/molecule/test/resources/playbooks/docker/create.yml
@@ -101,6 +101,8 @@
         hostname: "{{ item.hostname | default(item.name) }}"
         image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         pull: "{{ item.pull | default (omit) }}"
+        kernel_memory: "{{ item.kernel_memory | default(omit) }}"
+        memory: "{{ item.memory | default(omit) }}"
         state: started
         recreate: false
         log_driver: json-file


### PR DESCRIPTION
Signed-off-by: Lester Guerzon <lesterguerzon@pm.me>

This pull request adds support for the `memory` and `kernel_memory` parameters of `docker_container`, allowing users to specify memory limits for platforms using the docker driver.

#### PR Type

- Feature Pull Request
