### PR TITLE
Adopt pytest-plus

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 import os
 import pytest
-import sys
 
 pytest_plugins = ["helpers_namespace"]
 
@@ -19,29 +18,3 @@ def environ():
     # adds extra environment variables that may be needed during testing
     if not os.environ.get("TEST_BASE_IMAGE", ""):
         os.environ["TEST_BASE_IMAGE"] = "docker.io/pycontribs/centos:7"
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    """Assure passed test match PYTEST_REQPASS value.
-
-    Assures that pytest returns an error code when the number of expected passed
-    tests does not match the PYTEST_REQPASS value.  When not defined or zero
-    that functionality is ignored.
-    """
-    yield
-    req_passed = int(os.environ.get("PYTEST_REQPASS", "0"))
-    if req_passed and not config.option.collectonly:
-        passed = 0
-        for x in terminalreporter.stats.get("passed", []):
-            if x.when == "call" and x.outcome == "passed":
-                passed += 1
-        if passed != req_passed:
-            print(
-                "ERROR: {} passed test but expected number was {}. "
-                " If that is expected please update PYTEST_REQPASS value for the failed job in zuul.d/layout.yaml file.".format(
-                    passed, req_passed
-                ),
-                file=sys.stderr,
-            )
-            sys.exit(127)

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,6 +115,7 @@ test =
     pytest-html>=1.21.0; python_version >= '3.6'
     pytest-mock>=1.10.4, < 2
     pytest-verbose-parametrize>=1.7.0, < 2
+    pytest-plus
     pytest-sugar>=0.9.2, < 1
     pytest-xdist>=1.29.0, < 2
     pytest>=4.6.3, < 5


### PR DESCRIPTION
As the PYTEST_REQPASS feature is now included in pytest-plus plugin,
we can remove it from molecule and use the plugin instead.
