### PR TITLE
Ansible 2.10 compatibility changes

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -219,16 +219,6 @@ class Docker(Driver):
         """Implement Docker driver sanity checks."""
         log.info("Sanity checks: '{}'".format(self._name))
 
-        from ansible.module_utils.docker.common import HAS_DOCKER_PY
-
-        if not HAS_DOCKER_PY:
-            msg = (
-                "Missing Docker driver dependency. Please "
-                "install via 'molecule[docker]' or refer to "
-                "your INSTALL.rst driver documentation file"
-            )
-            sysexit_with_message(msg)
-
         try:
             import docker
             import requests

--- a/molecule/test/unit/driver/test_docker.py
+++ b/molecule/test/unit/driver/test_docker.py
@@ -138,11 +138,3 @@ def test_created(_instance):
 
 def test_converged(_instance):
     assert "false" == _instance._converged()
-
-
-def test_sanity_checks_missing_docker_dependency(mocker, _instance):
-    target = "ansible.module_utils.docker.common.HAS_DOCKER_PY"
-    mocker.patch(target, False)
-
-    with pytest.raises(SystemExit):
-        _instance.sanity_checks()

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ commands_pre =
     find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -path '*/__pycache__/*' -name '*.py[c|o]' -delete
     sh -c 'find {homedir}/.cache -type d -path "*/molecule_*" -exec rm -rfv \{\} +;'
 commands =
+    ansibledevel: ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
     # failsafe for preventing changes that may break pytest collection
     sh -c "PYTEST_ADDOPTS= python -m pytest -p no:cov --collect-only 2>&1 >{envlogdir}/collect.log"
     python -m pytest {posargs}

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -55,7 +55,7 @@
     vars:
       tox_envlist: py36-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 475
+        PYTEST_REQPASS: 474
 
 - job:
     name: molecule-tox-py36-ansible28-functional
@@ -72,7 +72,7 @@
     vars:
       tox_envlist: py36-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 475
+        PYTEST_REQPASS: 474
 
 - job:
     name: molecule-tox-py36-ansible29-functional
@@ -89,7 +89,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 475
+        PYTEST_REQPASS: 474
 
 - job:
     name: molecule-tox-py37-ansible28-functional
@@ -106,7 +106,7 @@
     vars:
       tox_envlist: py37-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 475
+        PYTEST_REQPASS: 474
 
 - job:
     name: molecule-tox-py37-ansible29-functional
@@ -125,7 +125,7 @@
     vars:
       tox_envlist: ansibledevel-unit
       tox_environment:
-        PYTEST_REQPASS: 475
+        PYTEST_REQPASS: 474
 
 - job:
     name: molecule-tox-devel-functional
@@ -144,7 +144,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 475
+        PYTEST_REQPASS: 474
 
 - job:
     name: molecule-tox-py37-ansible28-functional


### PR DESCRIPTION
- remove dependency on ansible internals for checking docker

Note that this is WIP, still trying to discover the extent of the damage.