### PR TITLE
Make devel jobs non-voting

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -136,6 +136,8 @@
 - job:
     name: molecule-tox-devel-unit
     parent: molecule-tox-py36
+    # until ansible-devel 2.10 changes are implemented
+    voting: false
     vars:
       tox_envlist: ansibledevel-unit
       tox_environment:
@@ -145,6 +147,8 @@
     name: molecule-tox-devel-functional
     parent: molecule-tox-py36
     timeout: 7200
+    # until nsible-devel 2.10 changes are implemented
+    voting: false
     vars:
       tox_envlist: ansibledevel-functional
       tox_environment:


### PR DESCRIPTION
Temporary measure to unblock CI until we have time to implement
all changes required by module migration made in devel branch.
