### PR TITLE
Avoid errors with delegated create and destroy templates

### DIFF
--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -6,31 +6,28 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   tasks:
-    # Developer must implement.
 
-    # Developer must map instance config.
-    # Mandatory configuration for Molecule to function.
+    # TODO: Developer must implement and populate 'server' variable
 
-    - name: Populate instance config dict
-      set_fact:
-        instance_conf_dict: {
-          'instance': "{{ }}",
-          'address': "{{ }}",
-          'user': "{{ }}",
-          'port': "{{ }}",
-          'identity_file': "{{ }}", }
-      with_items: "{{ server.results }}"
-      register: instance_config_dict
-      when: server.changed | bool
+    - when: server.changed | default(false) | bool
+      block:
+        - name: Populate instance config dict
+          set_fact:
+            instance_conf_dict: {
+              'instance': "{{ }}",
+              'address': "{{ }}",
+              'user': "{{ }}",
+              'port': "{{ }}",
+              'identity_file': "{{ }}", }
+          with_items: "{{ server.results }}"
+          register: instance_config_dict
 
-    - name: Convert instance config dict to a list
-      set_fact:
-        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
-      when: server.changed | bool
+        - name: Convert instance config dict to a list
+          set_fact:
+            instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
 
-    - name: Dump instance config
-      copy:
-        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
-        dest: "{{ molecule_instance_config }}"
-      when: server.changed | bool
+        - name: Dump instance config
+          copy:
+            content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+            dest: "{{ molecule_instance_config }}"
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -18,5 +18,5 @@
       copy:
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
-      when: server.changed | bool
+      when: server.changed | default(false) | bool
 {%- endraw %}

--- a/molecule/provisioner/ansible_playbook.py
+++ b/molecule/provisioner/ansible_playbook.py
@@ -58,6 +58,9 @@ class AnsiblePlaybook(object):
 
         :return: None
         """
+        if not self._playbook:
+            return
+
         # Pass a directory as inventory to let Ansible merge the multiple
         # inventory sources located under
         self.add_cli_arg("inventory", self._config.provisioner.inventory_directory)
@@ -93,6 +96,10 @@ class AnsiblePlaybook(object):
         """
         if self._ansible_command is None:
             self.bake()
+
+        if not self._playbook:
+            LOG.warning("Skipping, %s action has no playbook." % self._config.action)
+            return
 
         try:
             self._config.driver.sanity_checks()

--- a/molecule/provisioner/ansible_playbooks.py
+++ b/molecule/provisioner/ansible_playbooks.py
@@ -100,8 +100,10 @@ class AnsiblePlaybooks(object):
             elif os.path.exists(self._get_bundled_driver_playbook(section)):
                 return self._get_bundled_driver_playbook(section)
             elif section not in [
+                # these playbooks can be considered optional
                 "prepare",
                 "create",
+                "destroy",
                 "cleanup",
                 "side_effect",
                 "verify",


### PR DESCRIPTION
* Assure delegated templates can succesfully run
* Make create and destroy playbooks optionals, if they miss only
  a warning will be triggered.

Fix: #2621