### PR TITLE
Temporarily disable SSH pipelining. Resolves #2585

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -394,7 +394,7 @@ class Ansible(base.Base):
             "ssh_connection": {
                 "scp_if_ssh": True,
                 "control_path": "%(directory)s/%%h-%%p-%%r",
-                "pipelining": True,
+                "pipelining": False,
             },
         }
 

--- a/molecule/test/unit/provisioner/test_ansible.py
+++ b/molecule/test/unit/provisioner/test_ansible.py
@@ -109,7 +109,7 @@ def test_default_config_options_property(_instance):
         },
         "ssh_connection": {
             "control_path": "%(directory)s/%%h-%%p-%%r",
-            "pipelining": True,
+            "pipelining": False,
             "scp_if_ssh": True,
         },
     }
@@ -156,7 +156,7 @@ def test_config_options_property(_instance):
         },
         "ssh_connection": {
             "control_path": "%(directory)s/%%h-%%p-%%r",
-            "pipelining": True,
+            "pipelining": False,
             "scp_if_ssh": True,
         },
     }


### PR DESCRIPTION
This fixes a problem with the Podman driver related to an upstream Ansible issue.

Fixes: #2585