### PR TITLE
Paralelize host_vars

### DIFF
--- a/molecule/platforms.py
+++ b/molecule/platforms.py
@@ -75,9 +75,7 @@ class Platforms(object):
         :return: None
         """
         if parallelize_platforms:
-            config.config["platforms"] = util._parallelize_platforms(
-                config.config, config._run_uuid
-            )
+            util.parallelize_platform_names(config.config, config._run_uuid)
         self._config = config
 
     @property

--- a/molecule/test/unit/test_util.py
+++ b/molecule/test/unit/test_util.py
@@ -397,3 +397,23 @@ def test_underscore():
 )
 def test_merge_dicts(a, b, x):
     assert x == util.merge_dicts(a, b)
+
+
+def test_paralellize_platform_names():
+    config = dict(
+        platforms=[dict(name="pa"), dict(name="pb")],
+        provisioner=dict(
+            inventory=dict(host_vars=dict(pa=dict(x=3), pb=dict(y=4), pc=dict(z=5))),
+        ),
+    )
+
+    util.parallelize_platform_names(config, "123")
+
+    assert config == dict(
+        platforms=[dict(name="pa-123"), dict(name="pb-123")],
+        provisioner=dict(
+            inventory=dict(
+                host_vars={"pa-123": dict(x=3), "pb-123": dict(y=4), "pc": dict(z=5)}
+            ),
+        ),
+    )

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -55,7 +55,7 @@
     vars:
       tox_envlist: py36-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 492
 
 - job:
     name: molecule-tox-py36-ansible28-functional
@@ -72,7 +72,7 @@
     vars:
       tox_envlist: py36-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 492
 
 - job:
     name: molecule-tox-py36-ansible29-functional
@@ -89,7 +89,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 492
 
 - job:
     name: molecule-tox-py37-ansible28-functional
@@ -106,7 +106,7 @@
     vars:
       tox_envlist: py37-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 492
 
 - job:
     name: molecule-tox-py37-ansible29-functional
@@ -125,7 +125,7 @@
     vars:
       tox_envlist: ansibledevel-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 492
 
 - job:
     name: molecule-tox-devel-functional
@@ -144,7 +144,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 492
 
 - job:
     name: molecule-tox-py37-ansible28-functional


### PR DESCRIPTION
When Molecule is executed with the --parallel switch, it transforms the platform names in order to avoid name collisions on the service that is hosting the tests.

Currently, Molecule only parallelizes platform names and does not touch the inventory section at all. This makes it impossible to specify per-platform variables in the molecule.yml file.

For example, let us assume that we have this molecule.yml file:

    platforms:
      - name: my_platform
        # other stuff here

    provisioner:
      inventory:
        host_vars:
          my_platform:
            my_var: my_value

If we run such a scenario, the playbook tasks have access to the my_var variable. But as soon as we add the --parallel flag, this variable is no longer accessible because the host names from the platforms section and the provisioner sections do not match.

Changes in this PR ensure that when we parallelize platform names, we also parallelize any host_vars entries that match the original name. All other host_vars entries (the ones that do not match any of the platform names) are left alone and are not transformed.

#### PR Type

- Bugfix Pull Request
