### PR TITLE
Fix nodeset for molecule-tox-py36-ubuntu-bionic

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -25,6 +25,7 @@
 - job:
     name: molecule-tox-py36-ubuntu-bionic
     parent: molecule-tox-py36
+    nodeset: ubuntu-bionic-1vcpu
     attempts: 1
 
 - job:


### PR DESCRIPTION
Lack of nodeset mislead us into believing that it was really running on bionic.
