### PR TITLE
Implemented reset for docker driver

### DIFF
--- a/molecule/command/reset.py
+++ b/molecule/command/reset.py
@@ -23,6 +23,7 @@ import click
 
 from molecule import logger
 from molecule.command import base
+from molecule.api import drivers
 
 
 LOG = logger.get_logger(__name__)
@@ -45,3 +46,5 @@ def reset(ctx, scenario_name):  # pragma: no cover
     command_args = {"subcommand": subcommand}
 
     base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    for driver in drivers():
+        driver.reset()

--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -285,3 +285,12 @@ class Driver(object):
         p = os.path.join(self._path, "modules")
         if os.path.isdir(p):
             return p
+
+    def reset(self):
+        """Release all resources owned by molecule.
+
+        This is a destructive operation that would affect all resources managed
+        by molecule, regardless the scenario name.  Molecule will use metadata
+        like labels or tags to annotate resources allocated by it.
+        """
+        pass

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -232,3 +232,17 @@ class Docker(Driver):
                 "for managing the daemon"
             )
             sysexit_with_message(msg)
+
+    def reset(self):
+        import docker
+
+        client = docker.from_env()
+        for c in client.containers.list(filters={"label": "owner=molecule"}):
+            log.info("Stopping docker container %s ..." % c.id)
+            c.stop(timeout=3)
+        result = client.containers.prune(filters={"label": "owner=molecule"})
+        for c in result.get("ContainersDeleted") or []:
+            log.info("Deleted container %s" % c)
+        for n in client.networks.list(filters={"label": "owner=molecule"}):
+            log.info("Removing docker network %s ...." % n.name)
+            n.remove()

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -4,6 +4,9 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
   tasks:
     - name: Log into a Docker registry
       docker_login:
@@ -95,6 +98,7 @@
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
         state: present
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
       loop_control:
@@ -148,7 +152,7 @@
         restart_policy: "{{ item.restart_policy | default(omit) }}"
         restart_retries: "{{ item.restart_retries | default(omit) }}"
         tty: "{{ item.tty | default(omit) }}"
-        labels: "{{ item.labels | default(omit) }}"
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
         container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"

--- a/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
@@ -6,9 +6,7 @@ driver:
 platforms:
   - name: instance
     image: ${TEST_BASE_IMAGE}
-    networks:
-      - name: foo
-      - name: bar
+    # do not add networks here because they prevent parallel testing
     pre_build_image: true
 provisioner:
   name: ansible


### PR DESCRIPTION
From now on reset command will clean all docker containers and networks
that are managed my molecule, label owner=molecule

We also removed network creation from docker driver testing in order
to avoid concurrency issues.

