### PR TITLE
Correct typo in collection argument roles-file -> role-file

### DIFF
--- a/molecule/dependency/ansible_galaxy/collections.py
+++ b/molecule/dependency/ansible_galaxy/collections.py
@@ -12,7 +12,7 @@ LOG = logger.get_logger(__name__)
 class Collections(AnsibleGalaxyBase):
     """Collection-specific Ansible Galaxy dependency handling."""
 
-    FILTER_OPTS = ("roles-file", "roles-path")
+    FILTER_OPTS = ("role-file", "roles-path")
     COMMANDS = ("collection", "install")
 
     @property

--- a/molecule/test/unit/dependency/ansible_galaxy/test_collections.py
+++ b/molecule/test/unit/dependency/ansible_galaxy/test_collections.py
@@ -45,7 +45,7 @@ def _dependency_section_data():
     return {
         "dependency": {
             "name": "galaxy",
-            "options": {"foo": "bar", "v": True},
+            "options": {"foo": "bar", "v": True, "role-file": "bar.yml"},
             "env": {"FOO": "bar"},
         }
     }

--- a/molecule/test/unit/dependency/ansible_galaxy/test_roles.py
+++ b/molecule/test/unit/dependency/ansible_galaxy/test_roles.py
@@ -42,7 +42,7 @@ def _dependency_section_data():
     return {
         "dependency": {
             "name": "galaxy",
-            "options": {"foo": "bar", "v": True},
+            "options": {"foo": "bar", "v": True, "requirements-file": "foo.yml"},
             "env": {"FOO": "bar"},
         }
     }


### PR DESCRIPTION
Please include details of what it is, how to use it, how it's been tested
Please include an entry in the CHANGELOG.md if the change will impact users.

#### PR Type

- Bugfix Pull Request

This fixes a typo in #2609 that causes installs to fail when "role-file" is specified.