### PR TITLE
Removed --driver-template option

### DIFF
--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -50,9 +50,9 @@ class Scenario(base.Base):
 
         Initialize an existing role with Molecule:
 
-    .. program:: cd foo; molecule init scenario bar --role-name foo --driver-template path
+    .. program:: cd foo; molecule init scenario bar --role-name foo
 
-    .. option:: cd foo; molecule init scenario bar --role-name foo --driver-template path
+    .. option:: cd foo; molecule init scenario bar --role-name foo
 
         Initialize a new scenario using a local *cookiecutter* template for the
         driver configuration.
@@ -194,13 +194,6 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
     default="ansible",
     help="Name of verifier to initialize. (ansible)",
 )
-@click.option(
-    "--driver-template",
-    type=click.Path(exists=True, dir_okay=True, readable=True, resolve_path=True),
-    help="Path to a cookiecutter custom driver template to initialize the "
-    "scenario. If the driver template is not found locally, default "
-    "template will be used instead.",
-)
 def scenario(
     ctx,
     dependency_name,
@@ -210,7 +203,6 @@ def scenario(
     role_name,
     scenario_name,
     verifier_name,
-    driver_template,
 ):  # pragma: no cover
     """Initialize a new scenario for use with Molecule.
 
@@ -226,12 +218,6 @@ def scenario(
         "subcommand": __name__,
         "verifier_name": verifier_name,
     }
-
-    driver_template = driver_template or os.environ.get(
-        "MOLECULE_SCENARIO_DRIVER_TEMPLATE", None
-    )
-    if driver_template:
-        command_args["driver_template"] = driver_template
 
     s = Scenario(command_args)
     s.execute()

--- a/molecule/test/functional/docker/test_scenarios.py
+++ b/molecule/test/functional/docker/test_scenarios.py
@@ -136,51 +136,6 @@ def test_command_init_scenario_without_default_scenario_raises(temp_dir):
         assert msg in str(e.value.stderr)
 
 
-def test_command_init_scenario_with_custom_template_by_env_var(
-    temp_dir, resources_folder_path
-):
-    custom_template_dir_path = os.path.join(
-        resources_folder_path, "custom_scenario_template"
-    )
-    env = os.environ
-    env.update({"MOLECULE_SCENARIO_DRIVER_TEMPLATE": custom_template_dir_path})
-    pytest.helpers.init_scenario(temp_dir, "docker")
-    assert os.path.exists(
-        os.path.join(
-            temp_dir.strpath, "test-init", "molecule", "test-scenario", "README.md"
-        )
-    )
-
-
-def test_command_init_scenario_custom_template_precedence(
-    temp_dir, resources_folder_path
-):
-    role_directory = os.path.join(temp_dir.strpath, "test-role")
-    options = {}
-    cmd = sh.molecule.bake("init", "role", "test-role", **options)
-    pytest.helpers.run_command(cmd)
-    pytest.helpers.metadata_lint_update(role_directory)
-
-    with change_dir_to(role_directory):
-        invalid_template_dir_path = os.path.join(
-            resources_folder_path, "invalid_scenario_template"
-        )
-        env = os.environ
-        env.update({"MOLECULE_SCENARIO_DRIVER_TEMPLATE": invalid_template_dir_path})
-
-        custom_template_dir_path = os.path.join(
-            resources_folder_path, "custom_scenario_template"
-        )
-        options = {
-            "role_name": "test-role",
-            "driver_template": custom_template_dir_path,
-        }
-
-        # command line argument takes precedence, or it would fail
-        cmd = sh.molecule.bake("init", "scenario", "test-scenario", **options)
-        pytest.helpers.run_command(cmd, log=False)
-
-
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, scenario_name",
     [("overrride_driver", "docker", "default")],

--- a/molecule/test/unit/command/init/test_scenario.py
+++ b/molecule/test/unit/command/init/test_scenario.py
@@ -42,36 +42,11 @@ def _instance(_command_args):
 
 
 @pytest.fixture
-def custom_template_dir(resources_folder_path):
-    custom_template_dir_path = os.path.join(
-        resources_folder_path, "custom_scenario_template"
-    )
-    return custom_template_dir_path
-
-
-@pytest.fixture
 def invalid_template_dir(resources_folder_path):
     invalid_role_template_path = os.path.join(
         resources_folder_path, "invalid_scenario_template"
     )
     return invalid_role_template_path
-
-
-@pytest.fixture
-def custom_readme_content(custom_template_dir, _command_args):
-    readme_path = os.path.join(
-        custom_template_dir,
-        _command_args["driver_name"],
-        "{{cookiecutter.molecule_directory}}",
-        "{{cookiecutter.scenario_name}}",
-        "README.md",
-    )
-
-    custom_readme_content = ""
-    with open(readme_path, "r") as readme:
-        custom_readme_content = readme.read()
-
-    return custom_readme_content
 
 
 def test_execute(temp_dir, _instance, patched_logger_info, patched_logger_success):
@@ -106,45 +81,3 @@ def test_execute_with_invalid_driver(
 
     with pytest.raises(KeyError):
         _instance.execute()
-
-
-def test_execute_with_custom_template(
-    temp_dir, custom_template_dir, custom_readme_content, _command_args
-):
-    _command_args["driver_template"] = custom_template_dir
-
-    custom_template_instance = scenario.Scenario(_command_args)
-    custom_template_instance.execute()
-
-    assert os.path.isdir("./molecule/test-scenario")
-
-    readme_path = "./molecule/test-scenario/README.md"
-    assert os.path.isfile(readme_path)
-    with open(readme_path, "r") as readme:
-        assert readme.read() == custom_readme_content
-
-
-def test_execute_with_absent_custom_template(
-    temp_dir, _command_args, patched_logger_critical
-):
-    _command_args["driver_template"] = "absent_template_dir"
-
-    absent_template_instance = scenario.Scenario(_command_args)
-    with pytest.raises(SystemExit) as e:
-        absent_template_instance.execute()
-
-    assert e.value.code == 1
-    patched_logger_critical.assert_called_once()
-
-
-def test_execute_with_incorrect_template(
-    temp_dir, invalid_template_dir, _command_args, patched_logger_critical
-):
-    _command_args["driver_template"] = invalid_template_dir
-
-    invalid_template_instance = scenario.Scenario(_command_args)
-    with pytest.raises(SystemExit) as e:
-        invalid_template_instance.execute()
-
-    assert e.value.code == 1
-    patched_logger_critical.assert_called_once()

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -56,7 +56,7 @@
     vars:
       tox_envlist: py36-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 488
 
 - job:
     name: molecule-tox-py36-ansible28-functional
@@ -65,7 +65,7 @@
     vars:
       tox_envlist: py36-ansible28-functional
       tox_environment:
-        PYTEST_REQPASS: 72
+        PYTEST_REQPASS: 70
 
 - job:
     name: molecule-tox-py36-ansible29-unit
@@ -73,7 +73,7 @@
     vars:
       tox_envlist: py36-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 488
 
 - job:
     name: molecule-tox-py36-ansible29-functional
@@ -82,7 +82,7 @@
     vars:
       tox_envlist: py36-ansible29-functional
       tox_environment:
-        PYTEST_REQPASS: 72
+        PYTEST_REQPASS: 70
 
 - job:
     name: molecule-tox-py37-ansible28-unit
@@ -90,7 +90,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 488
 
 - job:
     name: molecule-tox-py37-ansible28-functional
@@ -99,7 +99,7 @@
     vars:
       tox_envlist: py37-ansible28-functional
       tox_environment:
-        PYTEST_REQPASS: 72
+        PYTEST_REQPASS: 70
 
 - job:
     name: molecule-tox-py37-ansible29-unit
@@ -107,7 +107,7 @@
     vars:
       tox_envlist: py37-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 488
 
 - job:
     name: molecule-tox-py37-ansible29-functional
@@ -116,7 +116,7 @@
     vars:
       tox_envlist: py37-ansible29-functional
       tox_environment:
-        PYTEST_REQPASS: 72
+        PYTEST_REQPASS: 70
 
 - job:
     name: molecule-tox-devel-unit
@@ -126,7 +126,7 @@
     vars:
       tox_envlist: ansibledevel-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 488
 
 - job:
     name: molecule-tox-devel-functional
@@ -137,7 +137,7 @@
     vars:
       tox_envlist: ansibledevel-functional
       tox_environment:
-        PYTEST_REQPASS: 72
+        PYTEST_REQPASS: 70
 
 - job:
     name: molecule-tox-py37-ansible28-unit
@@ -145,16 +145,16 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 491
+        PYTEST_REQPASS: 488
 
 - job:
     name: molecule-tox-py37-ansible28-functional
     parent: molecule-tox-py37
-    timeout: 7200
+    timeout: 7000
     vars:
       tox_envlist: py37-ansible28-functional
       tox_environment:
-        PYTEST_REQPASS: 72
+        PYTEST_REQPASS: 70
 
 - project:
     templates:


### PR DESCRIPTION
Removed `--driver-template` option from molecule init commands as it did add more complexity without a tangible outcome. Those still interested about this feature can use cookiecutter directly.