### PR TITLE
Remove quick start stub and links from docs

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -4,8 +4,6 @@
 Getting Started Guide
 *********************
 
-If you're looking to move a little faster, see the :ref:`quick-start`.
-
 The following guide will step through an example of developing and testing a
 new Ansible role. After reading this guide, you should be familiar with the
 basics of how to use Molecule and what it can offer.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,6 @@ Using Molecule
 .. toctree::
    :maxdepth: 1
 
-   Quickstart Guide <quick-start>
    Getting Started Guide <getting-started>
    Command Line Reference <usage>
    Configuration Guide <configuration>

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -1,7 +1,0 @@
-.. _quick-start:
-
-*****************
-Quick Start Guide
-*****************
-
-TODO.


### PR DESCRIPTION
Since the quick start doc isn't written, "If you're looking to move a little faster, see the quick start" is a bit of a contradiction.

#### PR Type
- Docs Pull Request
