### PR TITLE
Add memory-swap to create docker driver

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -126,6 +126,7 @@
         image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         pull: "{{ item.pull | default(omit) }}"
         memory: "{{ item.memory | default(omit) }}"
+        memory_swap: "{{ item.memory_swap | default(omit) }}"
         state: started
         recreate: false
         log_driver: json-file

--- a/molecule/test/resources/playbooks/docker/create.yml
+++ b/molecule/test/resources/playbooks/docker/create.yml
@@ -102,6 +102,7 @@
         image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         pull: "{{ item.pull | default (omit) }}"
         memory: "{{ item.memory | default(omit) }}"
+        memory_swap: "{{ item.memory_swap | default(omit) }}"
         state: started
         recreate: false
         log_driver: json-file


### PR DESCRIPTION
Add memory-swap parameter to docker driver

https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details

If --memory and --memory-swap are set to the same value, this prevents containers from using any swap. This is because --memory-swap is the amount of combined memory and swap that can be used, while --memory is only the amount of physical memory that can be used.


- Feature Pull Request
