### PR TITLE
WIP: support project path as option

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -170,6 +170,10 @@ def get_configs(args, command_args, ansible_args=(), glob_str=MOLECULE_GLOB):
      `ansible-playbook` command.
     :return: list
     """
+    molecule_project = os.getcwd()
+    if args.get("molecule_project"):
+        molecule_project = args.get("molecule_project")
+    project_glob_str = molecule_project + os.path.sep + glob_str
     configs = [
         config.Config(
             molecule_file=util.abs_path(c),
@@ -177,9 +181,9 @@ def get_configs(args, command_args, ansible_args=(), glob_str=MOLECULE_GLOB):
             command_args=command_args,
             ansible_args=ansible_args,
         )
-        for c in glob.glob(glob_str)
+        for c in glob.glob(project_glob_str)
     ]
-    _verify_configs(configs, glob_str)
+    _verify_configs(configs, project_glob_str)
 
     return configs
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -71,8 +71,11 @@ class Config(object, metaclass=NewInitCaller):
     :ref:`lint`, Platforms_, Provisioner_, Verifier_,
     :ref:`root_scenario`, and State_ references.
     """
-
-    def __init__(self, molecule_file, args={}, command_args={}, ansible_args=()):
+    def __init__(self,
+                 molecule_file,
+                 args={},
+                 command_args={},
+                 ansible_args=()):
         """
         Initialize a new config class and returns None.
 
@@ -132,7 +135,7 @@ class Config(object, metaclass=NewInitCaller):
 
     @property
     def project_directory(self):
-        return os.getenv("MOLECULE_PROJECT_DIRECTORY", os.getcwd())
+        return os.getenv("MOLECULE_PROJECT_DIRECTORY", self.args.get("molecule_project"))
 
     @property
     def cache_directory(self):

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -24,6 +24,7 @@ import click_completion
 import colorama
 import pkg_resources
 import sys
+import os
 
 from ansible.release import __version__ as ansible_version
 
@@ -84,11 +85,17 @@ def _version_string():
     default=ENV_FILE,
     help=("The file to read variables from when rendering molecule.yml. " "(.env.yml)"),
 )
+@click.option(
+    "--project",
+    "-p",
+    default=os.getcwd(),
+    help=("Path to a molecule project."),
+)
 @click.version_option(
     prog_name="molecule", version=molecule.__version__, message=_version_string()
 )
 @click.pass_context
-def main(ctx, debug, base_config, env_file):  # pragma: no cover
+def main(ctx, debug, base_config, env_file, project):  # pragma: no cover
     """
     Molecule aids in the development and testing of Ansible roles.
 
@@ -101,6 +108,7 @@ def main(ctx, debug, base_config, env_file):  # pragma: no cover
     ctx.obj["args"]["debug"] = debug
     ctx.obj["args"]["base_config"] = base_config
     ctx.obj["args"]["env_file"] = env_file
+    ctx.obj["args"]["molecule_project"] = project
 
 
 # runtime environment checks to avoid delayed failures

--- a/molecule/test/unit/command/test_base.py
+++ b/molecule/test/unit/command/test_base.py
@@ -266,7 +266,7 @@ def test_get_configs(config_instance):
 def test_get_configs_calls_verify_configs(_patched_verify_configs):
     base.get_configs({}, {})
 
-    _patched_verify_configs.assert_called_once_with([], "molecule/*/molecule.yml")
+    _patched_verify_configs.assert_called_once_with([], os.getcwd() + os.path.sep + "molecule/*/molecule.yml")
 
 
 def test_verify_configs(config_instance):


### PR DESCRIPTION
#### PR Type

- Feature Pull Request


Provides an optional `--project/-p` flag to allow molecule execution outside the current working directory.

```
cd /etc/molecule
molecule init role ~/testrole

molecule create -p ~/testrole
molecule converge -p ~/testrole
molecule destroy -p ~/testrole
molecule check -p ~/testrole
molecule dependency -p ~/testrole
molecule list -p ~/testrole
molecule lint -p ~/testrole
molecule reset -p ~/testrole
molecule test -p ~/testrole
molecule prepare -p ~/testrole
molecule verify -p ~/testrole
molecule idempotence -p ~/testrole
molecule matrix -p ~/testrole/ test
molecule side-effect -p ~/testrole
molecule syntax -p ~/testrole
```