### PR TITLE
docs: update python-libselinux to python3-libselinux EL8

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,7 +21,7 @@ CentOS 8
 
 .. code-block:: bash
 
-    $ sudo yum install -y gcc python3-pip python3-devel openssl-devel libselinux-python
+    $ sudo yum install -y gcc python3-pip python3-devel openssl-devel python3-libselinux
 
 Ubuntu 16.x
 -----------


### PR DESCRIPTION
Associated issue #2658


Please include details of what it is, how to use it, how it's been tested
Please include an entry in the CHANGELOG.md if the change will impact users.

The current installation guide for CentOS 8 will fail because python-libselinux is not available. This minor change points it at the python 3 version of that package that will succeed. Tested against CentOS 8 below.

```
[root@f106997568a0 /]# yum install libselinux-python
error: rpmdb: damaged header #173 retrieved -- skipping.
error: rpmdbNextIterator: skipping h#     173 blob size(4836): BAD, 8 + 16 * il(70) + dl(3708)
Last metadata expiration check: 0:20:06 ago on Mon 20 Apr 2020 12:30:43 PM UTC.
No match for argument: libselinux-python
Error: Unable to find a match: libselinux-python
[root@f106997568a0 /]# 
[root@f106997568a0 /]# yum install python3-libselinux
error: rpmdb: damaged header #173 retrieved -- skipping.
error: rpmdbNextIterator: skipping h#     173 blob size(4836): BAD, 8 + 16 * il(70) + dl(3708)
Last metadata expiration check: 0:20:26 ago on Mon 20 Apr 2020 12:30:43 PM UTC.
Dependencies resolved.
==============================================================================================================
 Package                          Architecture         Version                     Repository            Size
==============================================================================================================
Installing:
 python3-libselinux               x86_64               2.9-2.1.el8                 BaseOS               283 k

Transaction Summary
==============================================================================================================
Install  1 Package

Total download size: 283 k
Installed size: 874 k
Is this ok [y/N]: y
Downloading Packages:
python3-libselinux-2.9-2.1.el8.x86_64.rpm                                     2.2 MB/s | 283 kB     00:00    
--------------------------------------------------------------------------------------------------------------
Total                                                                         635 kB/s | 283 kB     00:00     
error: rpmdbNextIterator: skipping h#     173 blob size(4836): BAD, 8 + 16 * il(70) + dl(3708)
Running transaction check
error: rpmdbNextIterator: skipping h#     173 blob size(4836): BAD, 8 + 16 * il(70) + dl(3708)
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                      1/1 
  Installing       : python3-libselinux-2.9-2.1.el8.x86_64                                                1/1 
  Running scriptlet: python3-libselinux-2.9-2.1.el8.x86_64                                                1/1 
  Verifying        : python3-libselinux-2.9-2.1.el8.x86_64                                                1/1 

Installed:
  python3-libselinux-2.9-2.1.el8.x86_64                                                                       

Complete!
```


#### PR Type

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
