### PR TITLE
Improve dependencies

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -10,5 +10,7 @@ python3-devel [test platform:rpm !platform:centos-7]
 python3-libselinux [test platform:rpm !platform:centos-7]
 python3-netifaces [test !platform:centos-7 platform:rpm]
 
+openssl-devel [test platform:rpm]
+
 podman [platform:rpm]
 conmon [platform:centos-8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ install_requires =
     click-completion >= 0.5.1
     click-help-colors >= 0.6
     colorama >= 0.3.9
-    cookiecutter >= 1.6.0
+    cookiecutter >= 1.6.0, != 1.7.1
     python-gilt >= 1.2.1, < 2
     Jinja2 >= 2.10.1
     paramiko >= 2.5.0, < 3
@@ -116,7 +116,7 @@ test =
     pytest>=5.4.0, < 5.5
     testinfra >= 3.4.0
 lint =
-    ansible-lint >= 4.1.1a2, < 5
+    ansible-lint >= 4.2.0, < 5
     flake8 >= 3.6.0
     pre-commit >= 1.21.0
     yamllint >= 1.15.0


### PR DESCRIPTION
- avoid using 1.7.1 version of cookiecutter due to conflicts
- avoid using pre-release version of ansible-lint