### PR TITLE
WIP: add cookiecutter template option

### DIFF
--- a/molecule/command/init/init.py
+++ b/molecule/command/init/init.py
@@ -19,6 +19,8 @@
 #  DEALINGS IN THE SOFTWARE.
 """Base class used by init command."""
 
+import click
+
 from molecule.command import base
 from molecule import logger
 from molecule.command.init import role
@@ -28,8 +30,16 @@ LOG = logger.get_logger(__name__)
 
 
 @base.click_group_ex()
-def init():  # pragma: no cover
+@click.pass_context
+@click.option(
+    "--template-path",
+    "-t",
+    default=None,
+    help="Path to molecule cookiecutter template",
+)
+def init(ctx, template_path):  # pragma: no cover
     """Initialize a new role or scenario."""
+    ctx.obj["args"]["template_path"] = template_path
 
 
 init.add_command(role.role)

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -90,7 +90,12 @@ class Role(base.Base):
             self._process_templates(
                 template, self._command_args, scenario_base_directory
             )
-        self._process_templates("molecule", self._command_args, role_directory)
+
+        template_dir = self._command_args.get("template_path")
+        if template_dir:
+            self._process_templates(os.path.join(template_dir, "molecule"), self._command_args, role_directory)
+        else:
+            self._process_templates("molecule", self._command_args, role_directory)
 
         role_directory = os.path.join(role_directory, role_name)
         msg = "Initialized role in {} successfully.".format(role_directory)
@@ -141,6 +146,8 @@ def role(
     verifier_name,
 ):  # pragma: no cover
     """Initialize a new role for use with Molecule."""
+
+    template_path = ctx.obj.get("args").get("template_path")
     command_args = {
         "dependency_name": dependency_name,
         "driver_name": driver_name,
@@ -150,6 +157,7 @@ def role(
         "scenario_name": command_base.MOLECULE_DEFAULT_SCENARIO_NAME,
         "subcommand": __name__,
         "verifier_name": verifier_name,
+        "template_path": template_path
     }
 
     r = Role(command_args)

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -208,6 +208,8 @@ def scenario(
 
     If name is not specified the 'default' value will be used.
     """
+    template_path = ctx.obj.get("args").get("template_path")
+
     command_args = {
         "dependency_name": dependency_name,
         "driver_name": driver_name,
@@ -217,6 +219,7 @@ def scenario(
         "scenario_name": scenario_name,
         "subcommand": __name__,
         "verifier_name": verifier_name,
+        "template_path": template_path,
     }
 
     s = Scenario(command_args)

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -110,7 +110,12 @@ class Scenario(base.Base):
             self._process_templates(
                 template, self._command_args, scenario_base_directory
             )
-        self._process_templates("molecule", self._command_args, role_directory)
+
+        template_dir = self._command_args.get("template_path")
+        if template_dir:
+            self._process_templates(os.path.join(template_dir, "molecule"), self._command_args, role_directory)
+        else:
+            self._process_templates("molecule", self._command_args, role_directory)
 
         role_directory = os.path.join(role_directory, role_name)
         msg = "Initialized scenario in {} successfully.".format(scenario_directory)


### PR DESCRIPTION
Addresses #2657

#### PR Type

- Feature Pull Request

Allow users to define a cookiecutter template for configuring a molecule scenario

```
molecule init -t ~/mycookiecutter role ~/testrole
cd ~/testrole
molecule init -t ~/mycookiecutter scenario customscenario
``` 

Here we assume the cookiecutter directory structure reflects that of the [default](https://github.com/ansible-community/molecule/tree/master/molecule/cookiecutter) from the "molecule" directory down with changes only to `molecule.yml`. Do we want to make this available as an environment variable?