### PR TITLE
Allow drivers to overwrite template

### DIFF
--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -86,11 +86,11 @@ class Role(base.Base):
             api.drivers()[self._command_args["driver_name"]].template_dir(),
             api.verifiers()[self._command_args["verifier_name"]].template_dir(),
         ]
+        self._process_templates("molecule", self._command_args, role_directory)
         for template in templates:
             self._process_templates(
                 template, self._command_args, scenario_base_directory
             )
-        self._process_templates("molecule", self._command_args, role_directory)
 
         role_directory = os.path.join(role_directory, role_name)
         msg = "Initialized role in {} successfully.".format(role_directory)

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -106,11 +106,11 @@ class Scenario(base.Base):
             driver_template,
             api.verifiers()[self._command_args["verifier_name"]].template_dir(),
         ]
+        self._process_templates("molecule", self._command_args, role_directory)
         for template in templates:
             self._process_templates(
                 template, self._command_args, scenario_base_directory
             )
-        self._process_templates("molecule", self._command_args, role_directory)
 
         role_directory = os.path.join(role_directory, role_name)
         msg = "Initialized scenario in {} successfully.".format(scenario_directory)


### PR DESCRIPTION
Related to https://github.com/ansible-community/molecule-openstack/issues/3

Drivers can overwrite the cookiecutter template of molecule to define driver specific configuration. This allows "external" drivers to specify options that are driver specific, independently of molecule. 
For example the openstack needs to define flavor, image per vm that is booted ( ec2 same for instance type).

There is the alternative of populating the molecule template with external driver specific but i think that it's not the best way of addressing this.  

I've tested this with openstack/ec2/docker/podman drivers. Docker and podman templates are not affected, openstack/ec2 drivers either, but they will be able to change them in the future. 

#### PR Type
- Feature Pull Request
