### PR TITLE
Configure molecule-tox-py38-ansibledevel

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     packaging
     dockerfile
     # keep only N,N-1 ansible versions
-    py{36,37,38}-ansible{28,29}-{unit,functional}
+    py{36,37,38}-ansible{28,29,devel}-{unit,functional}
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -46,6 +46,7 @@ commands_pre =
     sh -c 'find {homedir}/.cache -type d -path "*/molecule_*" -exec rm -rfv \{\} +;'
 commands =
     ansibledevel: ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
+    python --version
     # failsafe for preventing changes that may break pytest collection
     sh -c "PYTEST_ADDOPTS= python -m pytest -p no:cov --collect-only 2>&1 >{envlogdir}/collect.log"
     python -m pytest {posargs}

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -136,10 +136,8 @@
     irrelevant-files: *doc-files
 
 - job:
-    name: molecule-tox-devel-unit
-    parent: molecule-tox-py36
-    # until ansible-devel 2.10 changes are implemented
-    voting: false
+    name: molecule-tox-py38-ansibledevel-unit
+    parent: molecule-tox-py38
     vars:
       tox_envlist: ansibledevel-unit
       tox_environment:
@@ -147,11 +145,9 @@
     irrelevant-files: *doc-files
 
 - job:
-    name: molecule-tox-devel-functional
-    parent: molecule-tox-py36
+    name: molecule-tox-py38-ansibledevel-functional
+    parent: molecule-tox-devel
     timeout: 9000
-    # until nsible-devel 2.10 changes are implemented
-    voting: false
     vars:
       tox_envlist: ansibledevel-functional
       tox_environment:


### PR DESCRIPTION
Not using pyXY in tox environment makes impossible to control which python version is used.

The only practical way to control python version was to include it in the tox environment name. Using a nodeset that only had desired python version was
ruled out because we do not have any with only py38, and because a change in node
may have undesired changes on the job (testing something else than we wanted).

Related: https://github.com/tox-dev/tox/issues/1565 

# WARNING - DO NOT MERGE
BE very careful with this change because current bug in tox makes it use other python version than the one we want so even if CI/CD reported green, it still failed to run the tests using python3.8
