### PR TITLE
Add hetznercloud plugin into molecule image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV PACKAGES="\
     "
 RUN apk add --update --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ ${PACKAGES}
 
-ENV MOLECULE_EXTRAS="docker,docs,windows,lint"
+ENV MOLECULE_EXTRAS="docker,docs,windows,lint,hetznercloud"
 
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=917006
 RUN python3 -m pip install -U wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,6 +120,8 @@ lint =
     flake8 >= 3.6.0
     pre-commit >= 1.21.0
     yamllint >= 1.15.0
+hetznercloud =
+    molecule-hetznercloud >= 0.2.0, < 1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Closes https://github.com/ansible-community/molecule/issues/2673.

Despite my unwillingness, the plugin is now tested again py36,37,38. The plugin has full integration testing implemented (see [CI build here](https://drone.autonomic.zone/autonomic-cooperative/molecule-hetznercloud/35)). The plugin is being used actively. The release schedule will follow semver. If this doesn't make it in I don't know what will ;)

> https://pypi.org/project/molecule-hetznercloud/