### PR TITLE
Treat warnings as errors during testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -142,14 +142,9 @@ junit_suite_name = molecule_test_suite
 norecursedirs = dist doc build .tox .eggs molecule/test/scenarios molecule/test/resources
 testpaths = molecule/test/
 filterwarnings =
-    # remove once https://github.com/boto/boto3/pull/1603 is released
-    ignore::DeprecationWarning:boto3
-    # remove once https://github.com/boto/botocore/issues/1615 is released
-    ignore::DeprecationWarning:botocore
-    # remove once https://github.com/cookiecutter/cookiecutter/pull/1127 is released
-    ignore::DeprecationWarning:cookiecutter
-    # remove once https://github.com/pytest-dev/pytest-cov/issues/327 is released
-    ignore::pytest.PytestWarning:pytest_cov
+    # treat warnings as errors unless we add them below
+    error
+    # ignore::UserWarning
 markers =
     extensive: marks tests that we want to skip by default, as they are indirectly covered by other tests
 


### PR DESCRIPTION
Harden Molecule own testing by treating any runtime warnings as errors.
