### PR TITLE
docs: Dockerfile no longer created by default

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -63,11 +63,7 @@ directories:
 .. code-block:: bash
 
     $ ls
-    Dockerfile.j2  INSTALL.rst  molecule.yml  converge.yml  verify.yml
-
-* Since `Docker`_ is the default :ref:`driver`, we find a ``Dockerfile.j2``
-  `Jinja2`_ template file in place. Molecule will use this file to build a
-  docker image to test your role against.
+    INSTALL.rst  molecule.yml  converge.yml  verify.yml
 
 * ``INSTALL.rst`` contains instructions on what additional software or setup
   steps you will need to take in order to allow Molecule to successfully


### PR DESCRIPTION
#### PR Type

- Bugfix Pull Request

The getting started guide listed a `Dockerfile.j2` file as being scaffolded when using `molecule init role`, but that is no longer the case, after https://github.com/ansible-community/molecule/commit/a74b2f3e24ffa3f61fde3253470856c2e13aaabc was added, and there was no longer a need for the lengthy process of setting up the custom local Docker image.

This PR just removes that from the getting-started section of the docs since I was a little nervous that my local scaffold didn't have a Dockerfile.j2.
