### PR TITLE
Fix issue with finding collections

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -426,7 +426,7 @@ class Ansible(base.Base):
             collections_paths_list.append(util.abs_path(collection_path))
         collections_paths_list.extend(
             [
-                util.abs_path(os.path.join(os.path.expanduser("~"), ".ansible")),
+                util.abs_path(os.path.join(os.path.expanduser("~"), ".ansible/collections")),
                 "/usr/share/ansible/collections",
                 "/etc/ansible/collections",
             ]

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -426,7 +426,9 @@ class Ansible(base.Base):
             collections_paths_list.append(util.abs_path(collection_path))
         collections_paths_list.extend(
             [
-                util.abs_path(os.path.join(os.path.expanduser("~"), ".ansible/collections")),
+                util.abs_path(
+                    os.path.join(os.path.expanduser("~"), ".ansible/collections")
+                ),
                 "/usr/share/ansible/collections",
                 "/etc/ansible/collections",
             ]


### PR DESCRIPTION
Collections are not in .ansible, but in .ansible/collections
```
Run ansible-galaxy collection install $COLLECTION_FILE
Process install dependency map
|Starting collection install process
|Installing 'ericsysmin.system:1.0.0' to '/home/runner/.ansible/collections/ansible_collections/ericsysmin/system'
```

But when molecule loads, it's attempting to load collections directly from /home/runner/.ansible which is not correct
```
ANSIBLE_COLLECTIONS_PATHS: /home/runner/.cache/molecule/ansible-collection-system/chrony/collections:/home/runner/.ansible:/usr/share/ansible/collections:/etc/ansible/collections
```

I was able to confirm that using 
```
ansible-galaxy collection install $COLLECTION_FILE -p /home/runner/.ansible
```
was a workaround, but definitely not the correct way.

#### PR Type

- Bugfix Pull Request
