### PR TITLE
Replace most centos:7 refereces with 8

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,4 +17,4 @@ def environ():
 
     # adds extra environment variables that may be needed during testing
     if not os.environ.get("TEST_BASE_IMAGE", ""):
-        os.environ["TEST_BASE_IMAGE"] = "docker.io/pycontribs/centos:7"
+        os.environ["TEST_BASE_IMAGE"] = "docker.io/pycontribs/centos:8"

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -36,7 +36,7 @@ and ``Dockerfile.j2`` as follows.
 Append the following code block to the end of ``Dockerfile.j2``. It creates an ``ansible``
 user with passwordless sudo privileges.
 
-The variable ``SUDO_GROUP`` depends on the target distribution. ``centos:7`` uses ``wheel``.
+The variable ``SUDO_GROUP`` depends on the target distribution. ``centos:8`` uses ``wheel``.
 
 .. code-block:: docker
 
@@ -56,7 +56,7 @@ Modify ``provisioner.inventory`` in ``molecule.yml`` as follows:
 
     platforms:
       - name: instance
-        image: centos:7
+        image: centos:8
         # …
 
 .. code-block:: yaml
@@ -77,8 +77,8 @@ An example for a different platform instance name:
 .. code-block:: yaml
 
     platforms:
-      - name: centos7
-        image: centos:7
+      - name: centos8
+        image: centos:8
         # …
 
 .. code-block:: yaml
@@ -88,8 +88,8 @@ An example for a different platform instance name:
       # …
       inventory:
         host_vars:
-          # setting for the platform instance named 'centos7'
-          centos7:
+          # setting for the platform instance named 'centos9'
+          centos9:
             ansible_user: ansible
 
 To test it, add the following task to ``tasks/main.yml``. It fails, because the
@@ -123,7 +123,7 @@ and command as follows.
 
     platforms:
       - name: instance
-        image: centos:7
+        image: centos:8
         command: /sbin/init
         tmpfs:
           - /run
@@ -131,7 +131,7 @@ and command as follows.
         volumes:
           - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
-Note that centos:7 image contains a `seccomp security profile for Docker`_ which enables the use of systemd.
+Note that centos:8 image contains a `seccomp security profile for Docker`_ which enables the use of systemd.
 When needed, such security profiles can be reused (for example `the one available in Fedora`_):
 
 .. code-block:: yaml
@@ -164,7 +164,7 @@ capabilities along with the same image, command, and volumes as shown in the ``n
 
     platforms:
       - name: instance
-        image: centos:7
+        image: centos:8
         command: /sbin/init
         capabilities:
           - SYS_ADMIN
@@ -178,7 +178,7 @@ same image and command as shown in the ``non-privileged`` example.
 
     platforms:
       - name: instance
-        image: centos:7
+        image: centos:8
         command: /sbin/init
         privileged: True
 

--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -6,11 +6,11 @@ driver:
 platforms:
 {%- if cookiecutter.driver_name == 'docker' %}
   - name: instance
-    image: docker.io/pycontribs/centos:7
+    image: docker.io/pycontribs/centos:8
     pre_build_image: true
 {%- elif cookiecutter.driver_name == 'podman' %}
   - name: instance
-    image: docker.io/pycontribs/centos:7
+    image: docker.io/pycontribs/centos:8
     pre_build_image: true
 {%- else %}
   - name: instance

--- a/molecule/data/validate-dockerfile.yml
+++ b/molecule/data/validate-dockerfile.yml
@@ -3,6 +3,9 @@
 - hosts: localhost
   vars:
     platforms:
+      # platforms supported as being managed by molecule/ansible, this does
+      # not mean molecule itself can run on them.
+      - image: alpine:edge
       - image: centos:7
       - image: centos:8
       - image: ubuntu:latest

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -120,7 +120,7 @@ class Docker(Driver):
     When attempting to utilize a container image with `systemd`_ as your init
     system inside the container to simulate a real machine, make sure to set
     the ``privileged``, ``volumes``, ``command``, and ``environment``
-    values. An example using the ``centos:7`` image is below:
+    values. An example using the ``centos:8`` image is below:
 
     .. note:: Do note that running containers in privileged mode is considerably
               less secure. For details, please reference `Docker Security
@@ -136,7 +136,7 @@ class Docker(Driver):
 
         platforms:
         - name: instance
-          image: centos:7
+          image: centos:8
           privileged: true
           volumes:
             - "/sys/fs/cgroup:/sys/fs/cgroup:rw"

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -101,7 +101,7 @@ class Podman(Driver):
     When attempting to utilize a container image with `systemd`_ as your init
     system inside the container to simulate a real machine, make sure to set
     the ``privileged``, ``volumes``, ``command``, and ``environment``
-    values. An example using the ``centos:7`` image is below:
+    values. An example using the ``centos:8`` image is below:
 
     .. note:: Do note that running containers in privileged mode is considerably
               less secure.
@@ -110,7 +110,7 @@ class Podman(Driver):
 
         platforms:
         - name: instance
-          image: centos:7
+          image: centos:8
           privileged: true
           command: "/usr/sbin/init"
           tty: True

--- a/tox.ini
+++ b/tox.ini
@@ -145,7 +145,7 @@ commands =
       --out-dir {toxinidir}/dist/ \
       {toxinidir}
     # metadata validation
-    python -m twine check .tox/dist/*
+    sh -c "python -m twine check .tox/dist/*"
 
 [testenv:snap]
 description = Builds a snap package


### PR DESCRIPTION
We had too many references to centos:7 which is no longer supported to be used to run molecule from (still supported as remote host).