### PR TITLE
Allow configuration of docker_network in platforms

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -41,7 +41,11 @@ class Docker(Driver):
     Molecule leverages Ansible's `docker_container`_ module, by mapping
     variables from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
-    .. _`docker_container`: https://docs.ansible.com/ansible/latest/docker_container_module.html
+    Molecule leverages Ansible's `docker_network`_ module, by mapping variable
+    ``docker_networks`` into ``create.yml`` and ``destroy.yml``.
+
+    .. _`docker_container`: https://docs.ansible.com/ansible/latest/modules/docker_container_module.html
+    .. _`docker_network`: https://docs.ansible.com/ansible/latest/modules/docker_network_module.html
     .. _`Docker Security Configuration`: https://docs.docker.com/engine/reference/run/#security-configuration
     .. _`Docker daemon socket options`: https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-socket-option
 
@@ -94,6 +98,11 @@ class Docker(Driver):
             dns_servers:
               - 8.8.8.8
             etc_hosts: "{'host1.example.com': '10.3.1.5'}"
+            docker_networks:
+              - name: foo
+                ipam_config:
+                  - subnet: '10.3.1.0/24'
+                    gateway: '10.3.1.254'
             networks:
               - name: foo
               - name: bar

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -92,14 +92,20 @@
 
     - name: Create docker network(s)
       docker_network:
-        name: "{{ item }}"
+        name: "{{ item.name }}"
+        appends: "{{ item.appends | default(omit) }}"
+        attachable: "{{ item.attachable | default(omit) }}"
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
+        enable_ipv6: "{{ item.enable_ipv6 | default(omit) }}"
+        force: "{{ item.force | default(omit) }}"
+        ipam_config: "{{ item.ipam_config | default(omit) }}"
         labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
         state: present
+        timeout: "{{ item.timeout | default(omit) }}"
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
       loop_control:
         label: "{{ item }}"

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -91,24 +91,11 @@
       delay: 30
 
     - name: Create docker network(s)
-      docker_network:
-        name: "{{ item.name }}"
-        appends: "{{ item.appends | default(omit) }}"
-        attachable: "{{ item.attachable | default(omit) }}"
-        docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
-        cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
-        enable_ipv6: "{{ item.enable_ipv6 | default(omit) }}"
-        force: "{{ item.force | default(omit) }}"
-        ipam_config: "{{ item.ipam_config | default(omit) }}"
-        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
-        state: present
-        timeout: "{{ item.timeout | default(omit) }}"
-      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+      action: docker_network
+      args: "{{ item }}"
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks('present', molecule_labels) }}"
       loop_control:
-        label: "{{ item }}"
+        label: "{{ item.name }}"
       no_log: false
 
     - name: Determine the CMD directives

--- a/molecule/provisioner/ansible/playbooks/docker/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/destroy.yml
@@ -35,7 +35,7 @@
 
     - name: Delete docker network(s)
       docker_network:
-        name: "{{ item }}"
+        name: "{{ item.name }}"
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"

--- a/molecule/provisioner/ansible/playbooks/docker/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/destroy.yml
@@ -34,15 +34,9 @@
       with_items: "{{ server.results }}"
 
     - name: Delete docker network(s)
-      docker_network:
-        name: "{{ item.name }}"
-        docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
-        cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
-        state: absent
-      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+      action: docker_network
+      args: "{{ item }}"
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks('absent') }}"
       loop_control:
-        label: "{{ item }}"
+        label: "{{ item.name }}"
       no_log: false

--- a/molecule/provisioner/ansible/plugins/filter/molecule_core.py
+++ b/molecule/provisioner/ansible/plugins/filter/molecule_core.py
@@ -57,22 +57,34 @@ def header(content):
     return util.molecule_prepender(content)
 
 
-def get_docker_networks(data):
+def get_docker_networks(data, state, labels={}):
     """Get list of docker networks."""
     network_list = []
     network_names = []
     for platform in data:
         if "docker_networks" in platform:
             for docker_network in platform["docker_networks"]:
+                if "labels" not in docker_network:
+                    docker_network["labels"] = {}
+                for key in labels:
+                    docker_network["labels"][key] = labels[key]
+
+                docker_network["state"] = state
+
                 if "name" in docker_network:
                     network_list.append(docker_network)
                     network_names.append(docker_network["name"])
+
+        # If a network name is defined for a platform but is not defined in
+        # docker_networks, add it to the network list.
         if "networks" in platform:
             for network in platform["networks"]:
                 if "name" in network:
                     name = network["name"]
                     if name not in network_names:
-                        network_list.append({"name": name})
+                        network_list.append(
+                            {"name": name, "labels": labels, "state": state}
+                        )
     return network_list
 
 

--- a/molecule/provisioner/ansible/plugins/filter/molecule_core.py
+++ b/molecule/provisioner/ansible/plugins/filter/molecule_core.py
@@ -60,12 +60,19 @@ def header(content):
 def get_docker_networks(data):
     """Get list of docker networks."""
     network_list = []
+    network_names = []
     for platform in data:
+        if "docker_networks" in platform:
+            for docker_network in platform["docker_networks"]:
+                if "name" in docker_network:
+                    network_list.append(docker_network)
+                    network_names.append(docker_network["name"])
         if "networks" in platform:
             for network in platform["networks"]:
                 if "name" in network:
                     name = network["name"]
-                    network_list.append(name)
+                    if name not in network_names:
+                        network_list.append({"name": name})
     return network_list
 
 

--- a/molecule/test/resources/playbooks/docker/create.yml
+++ b/molecule/test/resources/playbooks/docker/create.yml
@@ -71,15 +71,9 @@
       delay: 30
 
     - name: Create docker network(s)
-      docker_network:
-        name: "{{ item }}"
-        docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
-        cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
-        state: present
-      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+      action: docker_network
+      args: "{{ item }}"
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks('present') }}"
 
     - name: Determine the CMD directives
       set_fact:

--- a/molecule/test/resources/playbooks/docker/destroy.yml
+++ b/molecule/test/resources/playbooks/docker/destroy.yml
@@ -32,12 +32,6 @@
       no_log: item.failed
 
     - name: Delete docker network(s)
-      docker_network:
-        name: "{{ item }}"
-        docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
-        cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
-        tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
-        state: absent
-      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+      action: docker_network
+      args: "{{ item }}"
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks('absent') }}"


### PR DESCRIPTION
Map a list of docker_networks to [Ansible's docker_network module](https://docs.ansible.com/ansible/latest/modules/docker_network_module.html). This
change allows to define additional parameters, while the previous code
only allowed to define the name of the Docker network.

Keep backward compatibility if a network name is defined for the
platform, without a docker_network definition.

Example:
```
platforms:
  - name: instance1
    image: docker.io/pycontribs/centos:8
    docker_networks:
      - name: foo
        ipam_config:
          - subnet: "10.11.0.0/16"
            gateway: "10.11.0.254"
    networks:
      - name: foo
        ipv4_address: "10.11.0.1"
  - name: instance2
    image: docker.io/pycontribs/centos:8
    networks:
      - name: foo
        ipv4_address: "10.11.0.2"
  - name: instance3
    image: docker.io/pycontribs/centos:8
    networks:
      - name: bar
```
This will create 2 Docker networks `foo` and `bar`.
Docker network `foo` is created with a subnet 10.11.0.0/16 so we can define IP addresses for instance 1 and 2 and attach these interfaces to this network.
Docker network `bar` is created as previously.

Fixes: #1879