### PR TITLE
podman: remove reference to "volumes" setting

### DIFF
--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -100,8 +100,8 @@ class Podman(Driver):
 
     When attempting to utilize a container image with `systemd`_ as your init
     system inside the container to simulate a real machine, make sure to set
-    the ``privileged``, ``volumes``, ``command``, and ``environment``
-    values. An example using the ``centos:8`` image is below:
+    the ``privileged``, ``command``, and ``environment`` values. An example
+    using the ``centos:8`` image is below:
 
     .. note:: Do note that running containers in privileged mode is considerably
               less secure.


### PR DESCRIPTION
d6cdff04f5529d92a7f439a117929d05b3675159 removed the "volumes" parameter
from the podman example. Do not mention this setting in the preceding
paragraph.

#### PR Type

- Docs Pull Request