### PR TITLE
Clarify Docker bind-mount

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,8 +7,8 @@ Common Molecule Use Cases
 Docker
 ======
 
-Molecule can be executed via an Alpine Linux container by leveraging dind
-(Docker in Docker).  Currently, we only build images for the latest version
+Molecule can be executed via an Alpine Linux container by bind-mounting the
+Docker socket.  Currently, we only build images for the latest version
 of Ansible and Molecule.  In the future we may break this out into Molecule/
 Ansible versioned pairs.  The images are located on `quay.io`_.
 


### PR DESCRIPTION
Change language clarifying how Molecule can start sibling containers. In my experience, Docker-in-Docker generally refers to the build available at https://hub.docker.com/_/docker used for Docker development. This _may_ be a bit of a nit though 😄.

#### PR Type

- Docs Pull Request
