### PR TITLE
Add a relative path to the file in the gilt dependency 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ This version contains a big number of changes made over nine months below
 there is a summary of these. For upgrading, please visit
 `v3 migration checklist`_ page.
 
+* Add config path to gilt.yml
 * Supported Ansible versions are from now only N/N-1, (2.9 and 2.8), our
   ``master`` branch is also tested using ansible ``devel`` branch.
 * MAJOR: Providers are now installable drivers, python modules.


### PR DESCRIPTION
#### PR Type

- Feature Pull Request (https://github.com/ansible-community/molecule/issues/2702)

### Description

I added the ability to set the path to the file from the configuration to gilt dependencies. This will help you have a single file for many tests, and simplify the work of CI. The changes support both the relative and absolute path to the gilt file. And it doesn't break the default behavior.

