### PR TITLE
Replace mailing list with github discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Ask a question on Discussions area (NEW!)
+    url: https://github.com/ansible-community/molecule/discussions
+    about: Recommended place for questions, debates, consultation.
   - name: Ask a question on StackOverflow
     url: https://stackoverflow.com/questions/tagged/molecule
     about: For well defined questions and answers use StackOverflow
-  - name: Ask a question on molecule-users mailing-list
-    url: https://groups.google.com/forum/#!forum/molecule-users
-    about: Try using the classic mailing list, or `#ansible-molecule` irc channel.
   - name: Molecule Vagrant
     url: https://github.com/ansible-community/molecule-vagrant/
     about: For anything related to Vagrant driver, including *VirtualBox* backend.

--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,9 @@ Ansible Molecule
    :target: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
    :alt: Ansible Code of Conduct
 
-.. image:: https://img.shields.io/badge/Mailing%20lists-silver.svg
-   :target: https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information
-   :alt: Ansible mailing lists
+.. image:: https://img.shields.io/badge/Discussions-silver.svg
+   :target: https://github.com/ansible-community/molecule/discussions
+   :alt: Discussions
 
 .. image:: https://img.shields.io/badge/license-MIT-brightgreen.svg
    :target: LICENSE
@@ -61,7 +61,7 @@ Get Involved
 ============
 
 * Join us in the ``#ansible-molecule`` channel on `Freenode`_.
-* Join the discussion in `molecule-users Forum`_.
+* Check github `discussions`_.
 * Join the community working group by checking the `wiki`_.
 * Want to know about releases, subscribe to `ansible-announce list`_.
 * For the full list of Ansible email Lists, IRC channels see the
@@ -78,7 +78,7 @@ If you want to get moving fast and make a quick patch:
 And you're ready to make your changes!
 
 .. _`Freenode`: https://freenode.net
-.. _`molecule-users Forum`: https://groups.google.com/forum/#!forum/molecule-users
+.. _`discussions`: https://github.com/ansible-community/molecule/discussions
 .. _`wiki`: https://github.com/ansible/community/wiki/Molecule
 .. _`ansible-announce list`: https://groups.google.com/group/ansible-announce
 .. _`communication page`: https://docs.ansible.com/ansible/latest/community/communication.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ project_urls =
     CI: Zuul = https://dashboard.zuul.ansible.com/t/ansible/builds?project=ansible-community/molecule
     Code of Conduct = https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
     Documentation = https://molecule.readthedocs.io
-    Mailing lists = https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information
+    Discussions = https://github.com/ansible-community/molecule/discussions
     Source Code = https://github.com/ansible-community/molecule
 description = Molecule aids in the development and testing of Ansible roles
 long_description = file: README.rst


### PR DESCRIPTION
Removes references to google group mailing list with the newly
introduced discussions area on github.

This should help lowering the number of external services and make
easier to engage, especially for new users.