### PR TITLE
Support root containers for podman

### DIFF
--- a/molecule/model/schema_v3.py
+++ b/molecule/model/schema_v3.py
@@ -358,6 +358,7 @@ platforms_podman_schema = {
                 "cgroup_manager": {"type": "string"},
                 "storage_opt": {"type": "string"},
                 "storage_driver": {"type": "string"},
+                "rootless": {"type": "boolean"},
             },
         },
     }

--- a/molecule/provisioner/ansible/playbooks/podman/create.yml
+++ b/molecule/provisioner/ansible/playbooks/podman/create.yml
@@ -4,6 +4,7 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  become: "{{ not (item.rootless|default(true)) }}"
   tasks:
 
     - name: Log into a container registry

--- a/molecule/provisioner/ansible/playbooks/podman/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/podman/destroy.yml
@@ -4,6 +4,7 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  become: "{{ not (item.rootless|default(true)) }}"
   tasks:
     - name: Destroy molecule instance(s)
       shell: podman container exists {{ item.name }} && podman rm -f {{ item.name }} || true

--- a/molecule/test/resources/playbooks/podman/create.yml
+++ b/molecule/test/resources/playbooks/podman/create.yml
@@ -3,6 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
+  become: "{{ not (item.rootless|default(true)) }}"
   tasks:
     - name: Log into a container registry
       command: >

--- a/molecule/test/resources/playbooks/podman/destroy.yml
+++ b/molecule/test/resources/playbooks/podman/destroy.yml
@@ -4,6 +4,7 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  become: "{{ not (item.rootless|default(true)) }}"
   tasks:
     - name: Destroy molecule instance(s)
       shell: podman container exists {{ item.name }} && podman rm -f {{ item.name }} || true


### PR DESCRIPTION
By adding "rootless: false" support root containers for podman
driver.
#### PR Type

- Feature Pull Request

Fixes #2713