### PR TITLE
Refactored ansible-devel installation

### DIFF
--- a/tools/commands_pre.yml
+++ b/tools/commands_pre.yml
@@ -1,0 +1,10 @@
+#!/usr/bin/env ansible-playbook
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: Run network tasks in a resilient mode
+      shell: |
+        ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
+      register: result
+      until: result is not failed
+      retries: 3

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     packaging
     dockerfile
     # keep only N,N-1 ansible versions
-    py{36,37,38}-ansible{28,29}-{unit,functional}
+    py{36,37,38}-ansible{28,29,devel}-{unit,functional}
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -22,17 +22,18 @@ usedevelop = True
 passenv = *
 setenv =
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
+    PIP_DISABLE_VERSION_CHECK=1  # fu-pip for bulling everyone, worse than Clippy!
     PYTHONDONTWRITEBYTECODE=1
     _EXTRAS=-l --cov=molecule --no-cov-on-fail --cov-report xml:{envlogdir}/coverage.xml --html={envlogdir}/reports.html --self-contained-html
     # -n auto used only on unit as is not supported by functional yet
     # html report is used by Zuul CI to display reports
     unit: PYTEST_ADDOPTS=molecule/test/unit/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:-n auto}
     functional: PYTEST_ADDOPTS=molecule/test/functional/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:-k "not extensive"}
+    ansibledevel: ANSIBLE_DEVEL_WARNING=0
 deps =
     ansible28: ansible>=2.8,<2.9
-    ansible29: git+https://github.com/ansible/ansible.git@stable-2.9
+    ansible29: ansible>=2.9,<2.10
     # ^ after release change to ansible>=2.9,<2.10
-    ansibledevel: git+https://github.com/ansible/ansible.git
     dockerfile: ansible>=2.8
     selinux
 extras =
@@ -44,8 +45,11 @@ extras =
 commands_pre =
     find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -path '*/__pycache__/*' -name '*.py[c|o]' -delete
     sh -c 'find {homedir}/.cache -type d -path "*/molecule_*" -exec rm -rfv \{\} +;'
+    ansibledevel: pip uninstall -y ansible
+    ansibledevel: pip install git+https://github.com/ansible/ansible.git#egg=ansible-base
+    # devel does not have custom callbacks
+    ansibledevel: sh -c "unset ANSIBLE_STDOUT_CALLBACK; ansible-playbook ./tools/commands_pre.yml"
 commands =
-    ansibledevel: ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
     # failsafe for preventing changes that may break pytest collection
     sh -c "PYTEST_ADDOPTS= python -m pytest -p no:cov --collect-only 2>&1 >{envlogdir}/collect.log"
     python -m pytest {posargs}


### PR DESCRIPTION
Recent changes made to ansible-devel require additional hacks for avoiding conflicts betwee `ansible` and `ansible-base` python packages.
