### PR TITLE
Set correct default directory for tests

### DIFF
--- a/molecule/test/unit/verifier/test_ansible.py
+++ b/molecule/test/unit/verifier/test_ansible.py
@@ -57,7 +57,7 @@ def test_enabled_property(_instance):
 
 def test_directory_property(_instance):
     parts = _instance.directory.split(os.path.sep)
-    # default verifier is ansible, which keeps tests in molecule folder.
+    # The ansible verifier expects directory to end in molecule
     assert "molecule" == parts[-1]
 
 

--- a/molecule/test/unit/verifier/test_ansible.py
+++ b/molecule/test/unit/verifier/test_ansible.py
@@ -55,6 +55,12 @@ def test_enabled_property(_instance):
     assert _instance.enabled
 
 
+def test_directory_property(_instance):
+    parts = _instance.directory.split(os.path.sep)
+    # Unused by Ansible verifier
+    assert ["molecule", "default", "tests"] == parts[-3:]
+
+
 @pytest.mark.parametrize("config_instance", ["_verifier_section_data"], indirect=True)
 def test_options_property(_instance):
     x = {}

--- a/molecule/test/unit/verifier/test_ansible.py
+++ b/molecule/test/unit/verifier/test_ansible.py
@@ -55,12 +55,6 @@ def test_enabled_property(_instance):
     assert _instance.enabled
 
 
-def test_directory_property(_instance):
-    parts = _instance.directory.split(os.path.sep)
-    # The ansible verifier expects directory to end in molecule
-    assert "molecule" == parts[-1]
-
-
 @pytest.mark.parametrize("config_instance", ["_verifier_section_data"], indirect=True)
 def test_options_property(_instance):
     x = {}

--- a/molecule/verifier/ansible.py
+++ b/molecule/verifier/ansible.py
@@ -72,13 +72,6 @@ class Ansible(Verifier):
         env = util.merge_dicts(os.environ, self._config.env)
         return util.merge_dicts(env, self._config.provisioner.env)
 
-    @property
-    def directory(self):
-        return os.path.join(
-            self._config.scenario.directory,
-            self._config.config["verifier"].get("directory", "molecule"),
-        )
-
     def execute(self):
         if not self.enabled:
             msg = "Skipping, verifier is disabled."

--- a/molecule/verifier/ansible.py
+++ b/molecule/verifier/ansible.py
@@ -72,6 +72,13 @@ class Ansible(Verifier):
         env = util.merge_dicts(os.environ, self._config.env)
         return util.merge_dicts(env, self._config.provisioner.env)
 
+    @property
+    def directory(self):
+        return os.path.join(
+            self._config.scenario.directory,
+            self._config.config["verifier"].get("directory", "molecule"),
+        )
+
     def execute(self):
         if not self.enabled:
             msg = "Skipping, verifier is disabled."

--- a/molecule/verifier/base.py
+++ b/molecule/verifier/base.py
@@ -94,7 +94,7 @@ class Verifier(object):
     def directory(self):
         return os.path.join(
             self._config.scenario.directory,
-            self._config.config["verifier"].get("directory", "molecule"),
+            self._config.config["verifier"].get("directory", "tests"),
         )
 
     @property

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -119,13 +119,6 @@ class Testinfra(Verifier):
 
         return d
 
-    @property
-    def directory(self):
-        return os.path.join(
-            self._config.scenario.directory,
-            self._config.config["verifier"].get("directory", "tests"),
-        )
-
     # NOTE(retr0h): Override the base classes' options() to handle
     # ``ansible-galaxy`` one-off.
     @property


### PR DESCRIPTION
The default test directory created by verifiers is `molecule/default/tests` but the base `Verifier` class defaulted to `molecule/default/molecule`.  The `testinfra.py` verifier was overriding the `directory` property to correct the bug in the base class, but other spun-off verifiers aren't doing that (e.g. `molecule-goss` and `molecule-inspec`).  This change makes all the non-Ansible verifiers work again.

#### PR Type

- Bugfix Pull Request
