### PR TITLE
Add mol command alias

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,14 @@ Molecule supports only the latest two major versions of Ansible (N/N-1),
 meaning that if the latest version is 2.9.x, we will also test our code with
 2.8.x.
 
+Once installed, the command line can be called using any of the methods below:
+
+.. code-block:: bash
+
+    molecule ...
+    mol ...  # same as above, introduced in 3.0.5
+    python3 -m molecule ...  # python module calling method
+
 .. _`Ansible`: https://ansible.com
 
 .. _documentation:

--- a/molecule/test/unit/test_api.py
+++ b/molecule/test/unit/test_api.py
@@ -19,6 +19,8 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import pytest
+import sh
 from molecule import api
 
 
@@ -41,3 +43,13 @@ def test_api_verifiers():
     x = ["testinfra", "ansible"]
 
     assert all(elem in api.verifiers() for elem in x)
+
+
+def test_cli_mol():
+    cmd_molecule = sh.molecule.bake("--version")
+    x = pytest.helpers.run_command(cmd_molecule, log=False)
+    cmd_mol = sh.mol.bake("--version")
+    y = pytest.helpers.run_command(cmd_mol, log=False)
+    assert x.exit_code == y.exit_code
+    assert x.stderr == y.stderr
+    assert x.stdout == y.stdout

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,6 +124,7 @@ lint =
 [options.entry_points]
 console_scripts =
     molecule = molecule.__main__:main
+    mol = molecule.__main__:main
 molecule.driver =
     docker = molecule.driver.docker:Docker
     delegated = molecule.driver.delegated:Delegated

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -69,7 +69,7 @@
     vars:
       tox_envlist: py36-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 488
+        PYTEST_REQPASS: 489
     irrelevant-files: *doc-files
 
 - job:
@@ -90,7 +90,7 @@
     vars:
       tox_envlist: py36-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 488
+        PYTEST_REQPASS: 489
     irrelevant-files: *doc-files
 
 - job:
@@ -109,7 +109,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 488
+        PYTEST_REQPASS: 489
     irrelevant-files: *doc-files
 
 - job:
@@ -130,7 +130,7 @@
     vars:
       tox_envlist: py37-ansible29-unit
       tox_environment:
-        PYTEST_REQPASS: 488
+        PYTEST_REQPASS: 489
     irrelevant-files: *doc-files
 
 - job:
@@ -155,7 +155,7 @@
     vars:
       tox_envlist: py36-ansibledevel-unit
       tox_environment:
-        PYTEST_REQPASS: 488
+        PYTEST_REQPASS: 489
     irrelevant-files: *doc-files
 
 - job:
@@ -179,7 +179,7 @@
     vars:
       tox_envlist: py37-ansible28-unit
       tox_environment:
-        PYTEST_REQPASS: 488
+        PYTEST_REQPASS: 489
     irrelevant-files: *doc-files
 
 - job:


### PR DESCRIPTION
Makes it easier to run molecule by also installing a `mol` script. `mol` is the international abbreviation for molecule and it seems not to be used by any other known tool.

Using the abbreviated name can be proved useful not only for terminal usage but also when naming jobs in CI/CD pipelines, as their names could easily become very long.