### PR TITLE
Avoid failing tests due to docker deprecations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -145,6 +145,8 @@ testpaths = molecule/test/
 filterwarnings =
     # treat warnings as errors unless we add them below
     error
+    # https://github.com/docker/docker-py/issues/2566
+    ignore::DeprecationWarning:docker.*:
     # ignore::UserWarning
 markers =
     extensive: marks tests that we want to skip by default, as they are indirectly covered by other tests


### PR DESCRIPTION
DeprecationWarning from docker-py broke our testing.
Relates: https://github.com/docker/docker-py/issues/2566

