### PR TITLE
Remove universal wheel setting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [aliases]
 dists = clean --all sdist bdist_wheel
 
-[bdist_wheel]
-universal = 1
-
 [metadata]
 name = molecule
 url = https://github.com/ansible-community/molecule


### PR DESCRIPTION
This package does not support Python 2, so it should not be marked as a "universal wheel".
See: https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels

Running `setup.py bdist_wheel` will still generate a wheel, but it will not be marked as compatible with Python 2.