### PR TITLE
Remove custom callbacks from our tests

### DIFF
--- a/molecule/test/scenarios/cleanup/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/cleanup/molecule/default/molecule.yml
@@ -10,9 +10,6 @@ platforms:
     privileged: true
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   playbooks:
     cleanup: cleanup.yml
 verifier:

--- a/molecule/test/scenarios/dependency/molecule/ansible-galaxy/molecule.yml
+++ b/molecule/test/scenarios/dependency/molecule/ansible-galaxy/molecule.yml
@@ -8,9 +8,6 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
 scenario:

--- a/molecule/test/scenarios/dependency/molecule/gilt/molecule.yml
+++ b/molecule/test/scenarios/dependency/molecule/gilt/molecule.yml
@@ -8,9 +8,6 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
 scenario:

--- a/molecule/test/scenarios/dependency/molecule/shell/molecule.yml
+++ b/molecule/test/scenarios/dependency/molecule/shell/molecule.yml
@@ -9,9 +9,6 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
 scenario:

--- a/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
@@ -11,9 +11,6 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
     # keep this here to test that we convert integers to strings:

--- a/molecule/test/scenarios/driver/docker/molecule/multi-node/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/multi-node/molecule.yml
@@ -19,9 +19,6 @@ platforms:
 
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
 scenario:

--- a/molecule/test/scenarios/driver/podman/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/podman/molecule/default/molecule.yml
@@ -11,9 +11,6 @@ platforms:
       url: docker.io
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
     # keep this here to test that we convert integers to strings:

--- a/molecule/test/scenarios/driver/podman/molecule/multi-node/molecule.yml
+++ b/molecule/test/scenarios/driver/podman/molecule/multi-node/molecule.yml
@@ -22,9 +22,6 @@ platforms:
       - baz
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
 scenario:

--- a/molecule/test/scenarios/host_group_vars/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/host_group_vars/molecule/default/molecule.yml
@@ -12,9 +12,6 @@ platforms:
       - example_1
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   inventory:
     hosts:
       all:

--- a/molecule/test/scenarios/host_group_vars/molecule/links/molecule.yml
+++ b/molecule/test/scenarios/host_group_vars/molecule/links/molecule.yml
@@ -12,9 +12,6 @@ platforms:
       - example_1
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   inventory:
     links:
       hosts: ../../hosts

--- a/molecule/test/scenarios/idempotence/molecule/raises/molecule.yml
+++ b/molecule/test/scenarios/idempotence/molecule/raises/molecule.yml
@@ -8,9 +8,6 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
 # commented on purpose to validate that molecule will inherit it from
 # parent folder name:
 # scenario:

--- a/molecule/test/scenarios/interpolation/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/interpolation/molecule/default/molecule.yml
@@ -8,8 +8,5 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
 verifier:
   name: ansible

--- a/molecule/test/scenarios/overrride_driver/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/overrride_driver/molecule/default/molecule.yml
@@ -8,8 +8,5 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
 verifier:
   name: ansible

--- a/molecule/test/scenarios/plugins/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/plugins/molecule/default/molecule.yml
@@ -8,9 +8,6 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   env:
     ANSIBLE_ROLES_PATH: ../../../../resources/roles/
 verifier:

--- a/molecule/test/scenarios/side_effect/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/side_effect/molecule/default/molecule.yml
@@ -10,9 +10,6 @@ platforms:
     privileged: true
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   playbooks:
     side_effect: side_effect.yml
 verifier:

--- a/molecule/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
@@ -8,8 +8,5 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
 verifier:
   name: ansible

--- a/molecule/test/scenarios/verifier/molecule/testinfra/molecule.yml
+++ b/molecule/test/scenarios/verifier/molecule/testinfra/molecule.yml
@@ -8,9 +8,6 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      callback_whitelist: profile_roles,profile_tasks,timer
   env:
     ANSIBLE_ROLES_PATH: ../../../../resources/roles/
 scenario:


### PR DESCRIPTION
We do not really need to use custom callbacks when running our own
testing and removing them would reduce the amount of console output.

If we want to add them back, we can make use of shared config, and
avoid repeating it.

