### PR TITLE
Enable github label checking

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,0 @@
-
-Please include details of what it is, how to use it, how it's been tested
-Please include an entry in the CHANGELOG.md if the change will impact users.
-
-#### PR Type
-
-- Bugfix Pull Request
-- Docs Pull Request
-- Feature Pull Request

--- a/.github/workflows/edit.yml
+++ b/.github/workflows/edit.yml
@@ -1,0 +1,16 @@
+name: edit
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  labels:
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: yogevbd/enforce-label-action@2.1.0
+        with:
+          REQUIRED_LABELS_ANY: "bug,enhancement,feature,deprecated,major,skip-changelog"
+          REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label: bug,enhancement,feature,deprecated,major,skip-changelog"
+          BANNED_LABELS: "banned"


### PR DESCRIPTION
This should avoid merges of PRs that do not have correct changelog related labels added to them.
