### PR TITLE
Add -f alias for --force on prepare command

### DIFF
--- a/molecule/command/prepare.py
+++ b/molecule/command/prepare.py
@@ -122,6 +122,7 @@ class Prepare(base.Base):
 )
 @click.option(
     "--force/--no-force",
+    "-f",
     default=False,
     help="Enable or disable force mode. Default is disabled.",
 )


### PR DESCRIPTION
Please include details of what it is, how to use it, how it's been tested
Please include an entry in the CHANGELOG.md if the change will impact users.

#### PR Type

- Feature Pull Request

"molecule prepare --force" can now be accessed via "molecule prepare -f" as well