### PR TITLE
Avoid abridged click output

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -216,6 +216,7 @@ def click_group_ex():
     # yellow : special commands, like full test sequence, or login
     return click.group(
         cls=HelpColorsGroup,
+        context_settings=dict(max_content_width=9999),
         help_headers_color="yellow",
         help_options_color="green",
         help_options_custom_colors={

--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -216,6 +216,8 @@ def click_group_ex():
     # yellow : special commands, like full test sequence, or login
     return click.group(
         cls=HelpColorsGroup,
+        # Workaround to disable click help line truncation to ~80 chars
+        # https://github.com/pallets/click/issues/486
         context_settings=dict(max_content_width=9999),
         help_headers_color="yellow",
         help_options_color="green",


### PR DESCRIPTION
Fixes: #2733
Related: https://github.com/pallets/click/issues/486
