### PR TITLE
Add environment dict to lint calls

### DIFF
--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -93,7 +93,13 @@ class Lint(base.Base):
 
         try:
             LOG.info("Executing: %s" % cmd)
-            run(cmd, shell=True, universal_newlines=True, check=True)
+            run(
+                cmd,
+                env=self._config.env,
+                shell=True,
+                universal_newlines=True,
+                check=True,
+            )
         except Exception as e:
             util.sysexit_with_message("Lint failed: %s: %s" % (e, e))
 


### PR DESCRIPTION
Expose standard MOLECULE environment variables to the lint commands to
improve processing


- Feature Pull Request
