### PR TITLE
Removed default provisioner lint configuration

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -365,12 +365,6 @@ class Config(object, metaclass=NewInitCaller):
                     "side_effect": "side_effect.yml",
                     "verify": "verify.yml",
                 },
-                "lint": {
-                    "name": "ansible-lint",
-                    "enabled": True,
-                    "options": {},
-                    "env": {},
-                },
             },
             "scenario": {
                 "name": scenario_name,


### PR DESCRIPTION
As I know the linter is no longer used in the provisioner configuration.  
Accordingly, I assume that this is forgotten to remove from version 3.


#### PR Type

- Bugfix Pull Request