### PR TITLE
Check ansible-base version before ansible version 

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -97,9 +97,12 @@ class Config(object, metaclass=NewInitCaller):
     @property
     def ansible_version(self):
         """Return current version of ansible."""
-        return pkg_resources.parse_version(
-            pkg_resources.get_distribution("ansible").version
-        )
+        try:
+            ansible_version = pkg_resources.get_distribution("ansible-base").version
+        except Exception:
+            ansible_version = pkg_resources.get_distribution("ansible").version
+
+        return pkg_resources.parse_version(ansible_version)
 
     @property
     def ansible_collections_path(self):

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -49,13 +49,15 @@ def _version_string() -> str:
     v = pkg_resources.parse_version(molecule.__version__)
     color = "bright_yellow" if v.is_prerelease else "green"  # type: ignore
     msg = "molecule %s\n" % _colorize(molecule.__version__, color)
+
+    try:
+        ansible_version = pkg_resources.get_distribution("ansible-base").version
+    except Exception:
+        ansible_version = pkg_resources.get_distribution("ansible").version
+
     msg += _colorize(
         "   ansible==%s python==%s.%s"
-        % (
-            pkg_resources.get_distribution("ansible").version,
-            sys.version_info[0],
-            sys.version_info[1],
-        ),
+        % (ansible_version, sys.version_info[0], sys.version_info[1],),
         "bright_black",
     )
     return msg


### PR DESCRIPTION
Fixes `pkg_resources.DistributionNotFound: The 'ansible' distribution was not found and is required by the application` reported in #2757 when only ansible-base is installed.

This will report the version of ansible if < 2.10, the version of ansible-base if >= 2.10.

#### PR Type

- Bugfix Pull Request
