### PR TITLE
Assure env is passted to lint calls

### DIFF
--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -19,6 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 """Lint Command Module."""
 
+import os
 from subprocess import run
 
 import click
@@ -69,6 +70,10 @@ class Lint(base.Base):
         molecule.yml.
     """
 
+    @property
+    def env(self):
+        return util.merge_dicts(self._config.env, os.environ)
+
     def execute(self):
         """
         Execute the actions necessary to perform a `molecule lint` and \
@@ -94,11 +99,7 @@ class Lint(base.Base):
         try:
             LOG.info("Executing: %s" % cmd)
             run(
-                cmd,
-                env=self._config.env,
-                shell=True,
-                universal_newlines=True,
-                check=True,
+                cmd, env=self.env, shell=True, universal_newlines=True, check=True,
             )
         except Exception as e:
             util.sysexit_with_message("Lint failed: %s: %s" % (e, e))

--- a/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
@@ -17,3 +17,13 @@ provisioner:
     SOME_VALUE_AS_INFO: 1
 verifier:
   name: ansible
+lint: |
+  set -e
+  path_count=`env | grep -e '^PATH' | wc -l`
+  if [ x"$$path_count" == "x0" ]; then
+    exit 1
+  fi
+  molecule_count=`env | grep -e '^MOLECULE' | wc -l`
+  if [ x"$$molecule_count" == "x0" ]; then
+    exit 1
+  fi


### PR DESCRIPTION
Passing os.environ through to the value of the lint command and supplementing with the MOLECULE environment variables.

Fixes: #2781