### PR TITLE
Update docs to recommend docker:stable-dind

### DIFF
--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -105,7 +105,7 @@ Here is an example using Docker in Docker
 .. code-block:: yaml
 
     ---
-    image: docker:latest
+    image: docker:stable-dind
 
     services:
       - docker:dind


### PR DESCRIPTION
Using `stable-dind` image instead of `latest` can improve the trustworthiness/ease of use of the CI with GitLab, as the `latest` tag has proven to give unreliable results.