### PR TITLE
Add driver-name parameter to init_scenario test helper

### DIFF
--- a/molecule/test/functional/conftest.py
+++ b/molecule/test/functional/conftest.py
@@ -139,7 +139,7 @@ def init_scenario(temp_dir, driver_name):
         molecule_directory = pytest.helpers.molecule_directory()
         scenario_directory = os.path.join(molecule_directory, "test-scenario")
 
-        options = {"role_name": "test-init"}
+        options = {"role-name": "test-init", "driver-name": driver_name}
         cmd = sh.molecule.bake("init", "scenario", "test-scenario", **options)
         pytest.helpers.run_command(cmd)
 


### PR DESCRIPTION
Supply driver-name parameter inside init_scenario helper.

Fixes: #2797