### PR TITLE
Fixed linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,16 @@ exclude: |
     )
 repos:
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.0.8
+    rev: v5.4.2
     hooks:
       - id: isort
   - repo: https://github.com/python/black.git
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v2.4.0
+    rev: v3.2.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -25,26 +25,28 @@ repos:
       - id: debug-statements
         language_version: python3
   - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.7.9
+    rev: 3.8.3
     hooks:
       - id: flake8
         additional_dependencies:
+          # Pinned due to https://github.com/PyCQA/pydocstyle/pull/506
+          - pydocstyle<5.1.0
           - flake8-absolute-import
           - flake8-black>=0.1.1
           - flake8-docstrings>=1.5.0
         language_version: python3
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.20.0
+    rev: v1.24.2
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
         types: [file, yaml]
         entry: yamllint --strict
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.782
     hooks:
       - id: mypy
-        # empy args needed in order to match mypy cli behavior
+        # empty args needed in order to match mypy cli behavior
         args: []
         entry: mypy molecule/
         pass_filenames: false

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -99,7 +99,11 @@ class Lint(base.Base):
         try:
             LOG.info("Executing: %s" % cmd)
             run(
-                cmd, env=self.env, shell=True, universal_newlines=True, check=True,
+                cmd,
+                env=self.env,
+                shell=True,
+                universal_newlines=True,
+                check=True,
             )
         except Exception as e:
             util.sysexit_with_message("Lint failed: %s: %s" % (e, e))

--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -274,7 +274,11 @@ class Driver(object):
         class, allowing driver writers to define playbooks without having
         to override this method.
         """
-        p = os.path.join(self._path, "playbooks", step + ".yml",)
+        p = os.path.join(
+            self._path,
+            "playbooks",
+            step + ".yml",
+        )
         if os.path.isfile(p):
             return p
 

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -924,7 +924,10 @@ class Ansible(base.Base):
                 util.abs_path(os.path.join(self._config.project_directory, "library")),
                 util.abs_path(
                     os.path.join(
-                        os.path.expanduser("~"), ".ansible", "plugins", "modules",
+                        os.path.expanduser("~"),
+                        ".ansible",
+                        "plugins",
+                        "modules",
                     )
                 ),
                 "/usr/share/ansible/plugins/modules",

--- a/molecule/scenarios.py
+++ b/molecule/scenarios.py
@@ -29,8 +29,7 @@ LOG = logger.get_logger(__name__)
 
 
 class Scenarios(object):
-    """The Scenarios object consists of one to many scenario objects Molecule will \
-    execute."""
+    """The Scenarios groups one or more scenario objects Molecule will execute."""
 
     def __init__(self, configs, scenario_name=None):
         """

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -57,7 +57,11 @@ def _version_string() -> str:
 
     msg += _colorize(
         "   ansible==%s python==%s.%s"
-        % (ansible_version, sys.version_info[0], sys.version_info[1],),
+        % (
+            ansible_version,
+            sys.version_info[0],
+            sys.version_info[1],
+        ),
         "bright_black",
     )
     return msg

--- a/molecule/test/functional/test_command.py
+++ b/molecule/test/functional/test_command.py
@@ -319,7 +319,12 @@ def test_command_list_with_format_plain(scenario_to_test, with_scenario, expecte
             [["instance-1", ".*instance-1.*"], ["instance-2", ".*instance-2.*"]],
             "multi-node",
         ),
-        ("driver/delegated", "delegated", [["instance", ".*instance.*"]], "default",),
+        (
+            "driver/delegated",
+            "delegated",
+            [["instance", ".*instance.*"]],
+            "default",
+        ),
         (
             "driver/podman",
             "podman",

--- a/molecule/test/unit/command/test_lint.py
+++ b/molecule/test/unit/command/test_lint.py
@@ -24,7 +24,10 @@ from molecule.command import lint
 # config.Config._validate from executing.  Thus preventing odd side-effects
 # throughout patched.assert_called unit tests.
 def test_execute(
-    mocker, patched_logger_info, patched_config_validate, config_instance,
+    mocker,
+    patched_logger_info,
+    patched_config_validate,
+    config_instance,
 ):
     l = lint.Lint(config_instance)
     l.execute()


### PR DESCRIPTION
Among normal bumping of linters temporary pins down pydocstyle due to recent regression.

Related: https://github.com/PyCQA/pydocstyle/pull/506
