### PR TITLE
Remove dependency on ansible library

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -23,12 +23,12 @@ import os
 from uuid import uuid4
 
 import pkg_resources
-from ansible.module_utils.parsing.convert_bool import boolean
 
 from molecule import api, interpolation, logger, platforms, scenario, state, util
 from molecule.dependency import ansible_galaxy, gilt, shell
 from molecule.model import schema_v3
 from molecule.provisioner import ansible
+from molecule.util import boolean
 
 LOG = logger.get_logger(__name__)
 MOLECULE_DEBUG = boolean(os.environ.get("MOLECULE_DEBUG", "False"))

--- a/molecule/logger.py
+++ b/molecule/logger.py
@@ -22,16 +22,28 @@
 import logging
 import os
 import sys
+from typing import Any
 
 import colorama
-from ansible.module_utils.parsing.convert_bool import boolean as to_bool
+
+
+# Based on Ansible implementation
+def to_bool(a: Any) -> bool:
+    """Return a bool for the arg."""
+    if a is None or isinstance(a, bool):
+        return bool(a)
+    if isinstance(a, str):
+        a = a.lower()
+    if a in ("yes", "on", "1", "true", 1):
+        return True
+    return False
 
 
 def should_do_markup() -> bool:
     """Decide about use of ANSI colors."""
     py_colors = os.environ.get("PY_COLORS", None)
     if py_colors is not None:
-        return to_bool(py_colors, strict=False)
+        return to_bool(py_colors)
 
     return sys.stdout.isatty() and os.environ.get("TERM") != "dumb"
 

--- a/molecule/test/scenarios/plugins/library/project_library.py
+++ b/molecule/test/scenarios/plugins/library/project_library.py
@@ -21,6 +21,7 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 """testplugin role plugin library project_library."""
+from ansible.module_utils.basic import AnsibleModule
 
 
 def main():
@@ -34,7 +35,5 @@ def main():
 
     module.exit_json(**ansible_facts_dict)
 
-
-from ansible.module_utils.basic import *  # noqa
 
 main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,8 +63,6 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible >= 2.8  # keep it N/N-1
-
     cerberus >= 1.3.1
     click >= 7.0
     click-completion >= 0.5.1
@@ -98,6 +96,8 @@ docker =
 windows =
     pywinrm
 test =
+    ansible >= 2.8  # keep it N/N-1
+
     ansi2html
     coverage < 5  # https://github.com/pytest-dev/pytest-cov/issues/250
 


### PR DESCRIPTION
Removed runtime dependency on Ansible library which allows using Ansible only by interating with it via the command line. As a side effect, you now must assure you install ansible yourself as installing molecule will not install Ansible.

This change is mainly needed in order to accomodate changes related to Ansible 2.10 and the new ansible-base package. Molecule will be able to work with both versions on Ansible.