### PR TITLE
Removed multi-ansible version testing

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -116,14 +116,13 @@ Run all unit tests with coverage.
 
 .. code-block:: bash
 
-    $ tox -e 'py{27,35,36,37,38}-ansible{25,26,27,28}-unit'
+    $ tox -e 'py{27,35,36,37,38}-unit'
 
-Run all unit tests for a specific version of Python and Ansible (here Python 3.7
-and Ansible 2.7).
+Run all unit tests for a specific version of Python .
 
 .. code-block:: bash
 
-    $ tox -e py37-ansible28-unit
+    $ tox -e py37-unit
 
 Linting
 -------

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist =
     packaging
     dockerfile
     # keep only N,N-1 ansible versions
-    py{36,37,38}-ansible{28,29,devel}-{unit,functional}
+    py{36,37,38}-{unit,functional}
+    py{36,37,38}-{devel}
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -41,10 +42,8 @@ setenv =
     unit: PYTEST_ADDOPTS=molecule/test/unit/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:-n auto}
     functional: PYTEST_ADDOPTS=molecule/test/functional/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:-k "not extensive"}
 deps =
-    ansible28: ansible>=2.8,<2.9
-    ansible29: ansible>=2.9,<2.10
-    ansibledevel: ansible>=2.10.0a2,<2.11
-    dockerfile: ansible>=2.8
+    devel: ansible>=2.10.0a2,<2.11
+    dockerfile: ansible>=2.9.12
     selinux
 extras =
     docker

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -62,85 +62,43 @@
     irrelevant-files: *doc-files
 
 - job:
-    name: molecule-tox-py36-ansible28-unit
+    name: molecule-tox-py36-unit
     parent: molecule-tox-py36
-    # see: https://github.com/ansible-community/molecule/issues/2723
-    nodeset: ubuntu-bionic-1vcpu
     vars:
-      tox_envlist: py36-ansible28-unit
+      tox_envlist: py36-unit
       tox_environment:
         PYTEST_REQPASS: 489
     irrelevant-files: *doc-files
 
 - job:
-    name: molecule-tox-py36-ansible28-functional
+    name: molecule-tox-py36-functional
     parent: molecule-tox-py36
-    # see: https://github.com/ansible-community/molecule/issues/2723
-    nodeset: ubuntu-bionic-1vcpu
     timeout: 9000
     vars:
-      tox_envlist: py36-ansible28-functional
+      tox_envlist: py36-functional
       tox_environment:
         PYTEST_REQPASS: 37
     irrelevant-files: *doc-files
 
 - job:
-    name: molecule-tox-py36-ansible29-unit
-    parent: molecule-tox-py36
-    vars:
-      tox_envlist: py36-ansible29-unit
-      tox_environment:
-        PYTEST_REQPASS: 489
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py36-ansible29-functional
-    parent: molecule-tox-py36
-    timeout: 9000
-    vars:
-      tox_envlist: py36-ansible29-functional
-      tox_environment:
-        PYTEST_REQPASS: 37
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py37-ansible28-unit
-    parent: molecule-tox-py37
-    vars:
-      tox_envlist: py37-ansible28-unit
-      tox_environment:
-        PYTEST_REQPASS: 489
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py37-ansible28-functional
-    parent: molecule-tox-py37
-    timeout: 9000
-    vars:
-      tox_envlist: py37-ansible28-functional
-      tox_environment:
-        PYTEST_REQPASS: 37
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py37-ansible29-unit
+    name: molecule-tox-py37-unit
     parent: molecule-tox-py37
     # see: https://github.com/ansible-community/molecule/issues/2723
     nodeset: ubuntu-bionic-1vcpu
     vars:
-      tox_envlist: py37-ansible29-unit
+      tox_envlist: py37-unit
       tox_environment:
         PYTEST_REQPASS: 489
     irrelevant-files: *doc-files
 
 - job:
-    name: molecule-tox-py37-ansible29-functional
+    name: molecule-tox-py37-functional
     parent: molecule-tox-py37
     timeout: 9000
     # see: https://github.com/ansible-community/molecule/issues/2723
     nodeset: ubuntu-bionic-1vcpu
     vars:
-      tox_envlist: py37-ansible29-functional
+      tox_envlist: py37-functional
       tox_environment:
         PYTEST_REQPASS: 37
     irrelevant-files: *doc-files
@@ -171,29 +129,6 @@
         PYTEST_REQPASS: 37
     irrelevant-files: *doc-files
 
-- job:
-    name: molecule-tox-py37-ansible28-unit
-    parent: molecule-tox-py37
-    # see: https://github.com/ansible-community/molecule/issues/2723
-    nodeset: ubuntu-bionic-1vcpu
-    vars:
-      tox_envlist: py37-ansible28-unit
-      tox_environment:
-        PYTEST_REQPASS: 489
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py37-ansible28-functional
-    parent: molecule-tox-py37
-    timeout: 9000
-    # see: https://github.com/ansible-community/molecule/issues/2723
-    nodeset: ubuntu-bionic-1vcpu
-    vars:
-      tox_envlist: py37-ansible28-functional
-      tox_environment:
-        PYTEST_REQPASS: 37
-    irrelevant-files: *doc-files
-
 - project:
     templates:
       - publish-to-pypi
@@ -209,14 +144,10 @@
         - molecule-tox-packaging:
             vars:
               tox_envlist: packaging,dockerfile,build-containers
-        - molecule-tox-py36-ansible28-functional
-        - molecule-tox-py36-ansible28-unit
-        - molecule-tox-py36-ansible29-functional
-        - molecule-tox-py36-ansible29-unit
-        - molecule-tox-py37-ansible28-functional
-        - molecule-tox-py37-ansible28-unit
-        - molecule-tox-py37-ansible29-functional
-        - molecule-tox-py37-ansible29-unit
+        - molecule-tox-py36-functional
+        - molecule-tox-py36-unit
+        - molecule-tox-py37-functional
+        - molecule-tox-py37-unit
         - molecule-tox-py36-ansibledevel-functional
         - molecule-tox-py36-ansibledevel-unit
     gate:


### PR DESCRIPTION
From now on, we will be testing with a single version of Ansible, mainly because we no longer perform direct imports from Ansible.
