### PR TITLE
Serialize unit and functional testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -134,7 +134,7 @@ molecule.verifier =
 where = .
 
 [tool:pytest]
-addopts = -v -rxXs --capture=tee-sys --doctest-modules --durations 10 --color=yes
+addopts = -rxXs --capture=tee-sys --doctest-modules --durations 10 --color=yes
 doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 junit_suite_name = molecule_test_suite
 norecursedirs = dist doc build .tox .eggs molecule/test/scenarios molecule/test/resources

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     packaging
     dockerfile
     # keep only N,N-1 ansible versions
-    py{36,37,38}-{unit,functional}
+    py{36,37,38}
     py{36,37,38}-{devel}
 
 # do not enable skip missing to avoid CI false positives
@@ -28,6 +28,7 @@ passenv =
     HOME
     PODMAN_*
     TERM
+    SSH_AUTH_SOCK
 setenv =
     ANSIBLE_CONFIG={toxinidir}/dev/null
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
@@ -37,10 +38,6 @@ setenv =
     PYTHONUNBUFFERED=1
     MOLECULE_NO_LOG=0
     _EXTRAS=-l --cov=molecule --no-cov-on-fail --cov-report xml:{envlogdir}/coverage.xml --html={envlogdir}/reports.html --self-contained-html
-    # -n auto used only on unit as is not supported by functional yet
-    # html report is used by Zuul CI to display reports
-    unit: PYTEST_ADDOPTS=molecule/test/unit/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:-n auto}
-    functional: PYTEST_ADDOPTS=molecule/test/functional/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:-k "not extensive"}
 deps =
     devel: ansible>=2.10.0a2,<2.11
     dockerfile: ansible>=2.9.12
@@ -60,7 +57,11 @@ commands =
     pip check
     # failsafe for preventing changes that may break pytest collection
     sh -c "PYTEST_ADDOPTS= python -m pytest -p no:cov --collect-only 2>&1 >{envlogdir}/collect.log"
-    python -m pytest {posargs}
+    # -n auto used only on unit as is not supported by functional yet
+    # html report is used by Zuul CI to display reports
+    sh -c "PYTEST_REQPASS={env:PYTEST_REQPASS_UNIT:0} python -m pytest molecule/test/unit/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:-n auto} {posargs}"
+    sh -c "PYTEST_REQPASS={env:PYTEST_REQPASS_FUNC:0} python -m pytest molecule/test/functional/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:-k 'not extensive'}"
+
 whitelist_externals =
     find
     rm

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -61,74 +61,6 @@
       tox_envlist: snap
     irrelevant-files: *doc-files
 
-- job:
-    name: molecule-tox-py36-unit
-    parent: molecule-tox-py36
-    vars:
-      tox_envlist: py36-unit
-      tox_environment:
-        PYTEST_REQPASS: 489
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py36-functional
-    parent: molecule-tox-py36
-    timeout: 9000
-    vars:
-      tox_envlist: py36-functional
-      tox_environment:
-        PYTEST_REQPASS: 37
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py37-unit
-    parent: molecule-tox-py37
-    # see: https://github.com/ansible-community/molecule/issues/2723
-    nodeset: ubuntu-bionic-1vcpu
-    vars:
-      tox_envlist: py37-unit
-      tox_environment:
-        PYTEST_REQPASS: 489
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py37-functional
-    parent: molecule-tox-py37
-    timeout: 9000
-    # see: https://github.com/ansible-community/molecule/issues/2723
-    nodeset: ubuntu-bionic-1vcpu
-    vars:
-      tox_envlist: py37-functional
-      tox_environment:
-        PYTEST_REQPASS: 37
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py36-ansibledevel-unit
-    parent: molecule-tox-py36
-    # see: https://github.com/ansible-community/molecule/issues/2723
-    nodeset: ubuntu-bionic-1vcpu
-    # until ansible-devel 2.10 changes are implemented
-    voting: false
-    vars:
-      tox_envlist: py36-ansibledevel-unit
-      tox_environment:
-        PYTEST_REQPASS: 489
-    irrelevant-files: *doc-files
-
-- job:
-    name: molecule-tox-py36-ansibledevel-functional
-    parent: molecule-tox-py36
-    timeout: 9000
-    # see: https://github.com/ansible-community/molecule/issues/2723
-    nodeset: ubuntu-bionic-1vcpu
-    voting: false
-    vars:
-      tox_envlist: py36-ansibledevel-functional
-      tox_environment:
-        PYTEST_REQPASS: 37
-    irrelevant-files: *doc-files
-
 - project:
     templates:
       - publish-to-pypi
@@ -144,11 +76,20 @@
         - molecule-tox-packaging:
             vars:
               tox_envlist: packaging,dockerfile,build-containers
-        - molecule-tox-py36-functional
-        - molecule-tox-py36-unit
-        - molecule-tox-py37-functional
-        - molecule-tox-py37-unit
-        - molecule-tox-py36-ansibledevel-functional
-        - molecule-tox-py36-ansibledevel-unit
+        - molecule-tox-py36:
+            vars:
+              PYTEST_REQPASS_UNIT: 489
+              PYTEST_REQPASS_FUNC: 37
+            irrelevant-files: *doc-files
+        - molecule-tox-py37:
+            vars:
+              PYTEST_REQPASS_UNIT: 489
+              PYTEST_REQPASS_FUNC: 37
+            irrelevant-files: *doc-files
+        - molecule-tox-py38:
+            vars:
+              PYTEST_REQPASS_UNIT: 489
+              PYTEST_REQPASS_FUNC: 37
+            irrelevant-files: *doc-files
     gate:
       jobs: *jobs


### PR DESCRIPTION
Avoid use of different tox environments for unit and functional testing. This will considerably simplify testing matrix.
