### PR TITLE
Include build-containers in CI/CD

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,6 +30,15 @@ jobs:
             PREFIX: PYTEST_REQPASS=432
           - tox_env: packaging
           - tox_env: dockerfile
+          - tox_env: build-containers
+            needs:
+              - dockerfile
+              - docs
+              - lint
+              - packaging
+              - py36
+              - py37
+              - py38
 
     steps:
       - uses: actions/checkout@v1
@@ -125,3 +134,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.pypi_password }}
+# No need to publish to quay.io from here as they do it when a new tag
+# is pushed on git.

--- a/tools/build-containers.py
+++ b/tools/build-containers.py
@@ -24,6 +24,7 @@ if __name__ == "__main__":
     version = get_version()
     version_tag = version.replace("+", "-")
     image_name = os.environ.get("QUAY_REPO", "quay.io/ansible/molecule")
+    publish = os.environ.get("PUBLISH", None) == "1"
 
     expire = ""
     tagging_args = ""
@@ -38,7 +39,7 @@ if __name__ == "__main__":
         tagging_args += "-t " + image_name + ":latest "
         tags_to_push.append("latest")
     # if on master, we want to also move the master tag
-    if os.environ.get("TRAVIS_BRANCH", None) == "master":
+    if publish:
         tagging_args += "-t " + image_name + ":master "
         tags_to_push.append("master")
 
@@ -65,7 +66,7 @@ if __name__ == "__main__":
     )
 
     # Decide to push when all conditions below are met:
-    if os.environ.get("TRAVIS_BUILD_STAGE_NAME", None) == "deploy":
+    if publish:
         run(f"{engine} login quay.io")
         for tag in tags_to_push:
             run(f"{engine} push {image_name}:{tag}")

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,11 @@ passenv =
     DOCKER_*
     GITHUB_*
     HOME
-    PYTEST_*
     PODMAN_*
+    PUBLISH
+    PYTEST_*
     SSH_AUTH_SOCK
     TERM
-    HOME
 setenv =
     ANSIBLE_CONFIG={toxinidir}/dev/null
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
@@ -122,6 +122,7 @@ extras =
     selinux
 
 [testenv:build-containers]
+description = Builds and eventually publishes molecule container will all plugins
 # skip under Windows
 platform = ^darwin|^linux
 # `usedevelop = True` overrided `skip_install` instruction, it's unwanted


### PR DESCRIPTION
- assures we test build-containers on ci
- updated logic for publishing containers
- no need to publish from github-actions as we rely on quay to do it
