### PR TITLE
Added hint about current directory for "initialization"

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -40,7 +40,8 @@ You should then see a ``my-new-role`` folder in your current directory.
 
     For future reference, if you want to initialize Molecule within an
     existing role, you would use the ``molecule init scenario -r
-    my-role-name`` command.
+    my-role-name`` command from within the role's directory (e.g.
+    ``my-role-name/``).
 
 Molecule Scenarios
 ------------------


### PR DESCRIPTION
##### SUMMARY

It took me quite some time and the help of this https://github.com/ansible-community/molecule/issues/1133 issue (where the author also needed quite some time) to figure out that I was running this command from the wrong directory (namely the parent of the role's directory).

I think it would help if the docs were a bit more clear about this :)

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr