### PR TITLE
Sort tests files for testinfra by filename

### DIFF
--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -200,7 +200,7 @@ class Testinfra(Verifier):
 
         :return: list
         """
-        return [filename for filename in util.os_walk(self.directory, "test_*.py")]
+        return sorted([filename for filename in util.os_walk(self.directory, "test_*.py")])
 
     def schema(self):
         return {

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -200,7 +200,9 @@ class Testinfra(Verifier):
 
         :return: list
         """
-        return sorted([filename for filename in util.os_walk(self.directory, "test_*.py")])
+        return sorted(
+            [filename for filename in util.os_walk(self.directory, "test_*.py")]
+        )
 
     def schema(self):
         return {


### PR DESCRIPTION
With sorted, tests files for testinfra are now executed in the same order, since os.walk return a list in an arbitrary maner.

- Bugfix #2845
