### PR TITLE
Avoid importlib-metadata conflict with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ passenv =
     SSH_AUTH_SOCK
     TERM
 setenv =
-    ANSIBLE_CONFIG={toxinidir}/dev/null
+    ANSIBLE_CONFIG={toxinidir}/.ansible.cfg
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
     ANSIBLE_DISPLAY_FAILED_STDERR=1
     ANSIBLE_VERBOSITY=1
@@ -51,6 +51,7 @@ deps =
     devel: ansible>=2.10.0a2,<2.11
     dockerfile: ansible>=2.9.12
     selinux
+    py{36,37}: importlib-metadata<2,>=0.12
 extras =
     docker
     lint


### PR DESCRIPTION
importlib-metadata does not support installing versions after 2.0 on
Python versions prior to py38.
Also fix the path for ANSIBLE_CONFIG file

#### PR Type

- Bugfix Pull Request
