### PR TITLE
Update molecule tag in examples.rst

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -21,7 +21,7 @@ follows.
         -v "$(pwd)":/tmp/$(basename "${PWD}"):ro \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -w /tmp/$(basename "${PWD}") \
-        quay.io/ansible/molecule:2.20 \
+        quay.io/ansible/molecule:3.0.8 \
         molecule test
 
 .. _`quay.io`: https://quay.io/repository/ansible/molecule


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
Updating to the latest version, since in the documentation it is still using an old version.  Also, quay.io/ansible/molecule:latest pulls a 2.20 image, not the new v3.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
