### PR TITLE
Fixed CustomLogger super call

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,11 +23,11 @@ jobs:
           - tox_env: lint
           - tox_env: docs
           - tox_env: py36
-            PREFIX: PYTEST_REQPASS=432
+            PREFIX: PYTEST_REQPASS=433
           - tox_env: py37
-            PREFIX: PYTEST_REQPASS=432
+            PREFIX: PYTEST_REQPASS=433
           - tox_env: py38
-            PREFIX: PYTEST_REQPASS=432
+            PREFIX: PYTEST_REQPASS=433
           - tox_env: packaging
           - tox_env: dockerfile
           - tox_env: build-containers

--- a/molecule/logger.py
+++ b/molecule/logger.py
@@ -73,7 +73,7 @@ class CustomLogger(logging.getLoggerClass()):  # type: ignore  # see https://sam
 
     def __init__(self, name, level=logging.NOTSET):
         """Construct CustomLogger."""
-        super(logging.getLoggerClass(), self).__init__(name, level)
+        super(CustomLogger, self).__init__(name, level)
         logging.addLevelName(SUCCESS, "SUCCESS")
         logging.addLevelName(OUT, "OUT")
 

--- a/molecule/test/unit/test_logger.py
+++ b/molecule/test/unit/test_logger.py
@@ -20,6 +20,7 @@
 
 from __future__ import print_function
 
+import logging
 import sys
 
 import colorama
@@ -177,3 +178,13 @@ def test_markup_detection_tty_no(mocker):
     assert not logger.should_do_markup()
     mocker.resetall()
     mocker.stopall()
+
+
+def test_logger_class():
+    class FooLogger(logging.getLoggerClass()):
+        """stub logger that subclasses logging.getLoggerClass()."""
+
+    logging.setLoggerClass(FooLogger)
+
+    # this test throws RecursionError prior to bugfix
+    assert FooLogger("foo")


### PR DESCRIPTION
In cases where another logger uses getLoggerClass to subclass and then
setLoggerClass's itself,  molecules logger passes the wrong value to
super() causing a recursionError.

Please include details of what it is, how to use it, how it's been tested

#### PR Type
- Bugfix Pull Request
