### PR TITLE
Enable folding sections when run under Travis

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,11 +23,11 @@ jobs:
           - tox_env: lint
           - tox_env: docs
           - tox_env: py36
-            PREFIX: PYTEST_REQPASS=433
+            PREFIX: PYTEST_REQPASS=434
           - tox_env: py37
-            PREFIX: PYTEST_REQPASS=433
+            PREFIX: PYTEST_REQPASS=434
           - tox_env: py38
-            PREFIX: PYTEST_REQPASS=433
+            PREFIX: PYTEST_REQPASS=434
           - tox_env: packaging
           - tox_env: dockerfile
           - tox_env: build-containers

--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -21,12 +21,14 @@
 
 import abc
 import collections
+import functools
 import glob
 import os
 import shutil
 from typing import Any, Callable
 
 import click
+import colorama
 from click_help_colors import HelpColorsCommand, HelpColorsGroup
 
 import molecule.scenarios
@@ -122,6 +124,33 @@ def execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args=()
                 raise
 
 
+def _output_for_ci(func):
+    is_travis = os.getenv("TRAVIS") and os.getenv("CI")
+    if not is_travis:
+        return func
+
+    @functools.wraps(func)
+    def travis_wrapper(config, subcommand):
+        print(
+            (
+                "travis_fold:start:{0}.{1}"
+                "{2}Molecule --> Scenario: '{0}' --> Action: '{1}'{3}"
+            ).format(
+                config.scenario.name,
+                subcommand,
+                colorama.Style.BRIGHT + colorama.Fore.CYAN,
+                colorama.Style.RESET_ALL,
+            )
+        )
+        try:
+            return func(config, subcommand)
+        finally:
+            print("travis_fold:end:{}.{}".format(config.scenario.name, subcommand))
+
+    return travis_wrapper
+
+
+@_output_for_ci
 def execute_subcommand(config, subcommand):
     """Execute subcommand."""
     command_module = getattr(molecule.command, subcommand)


### PR DESCRIPTION
Add output when molecule is running in travis-ci to make the logs easier to jump through.
Travis log folding is explained [here](https://github.com/travis-ci/travis-ci/issues/2285).

#### PR Type
- Feature Pull Request