### PR TITLE
Documentation: fixing --parallel flag position and typos

### DIFF
--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -332,7 +332,7 @@ we export a ``TOX_ENVNAME`` environment variable, it's the name of our tox env.
 
 
 You also must include the ``TOX_ENVNAME`` variable in name of each platform in
-``molecule.yml`` configuration file. This way, ther names won't create any
+``molecule.yml`` configuration file. This way, their names won't create any
 conflict.
 
 .. code-block:: yaml

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -216,7 +216,7 @@ When needed, such security profiles can be reused (for example `the one availabl
           - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 The developer can also opt to `start the container with extended privileges`_,
-by either giving it ``SYS_ADMIN`` capabilites or running it in ``privileged`` mode.
+by either giving it ``SYS_ADMIN`` capabilities or running it in ``privileged`` mode.
 
 .. important::
 
@@ -385,9 +385,6 @@ Running Molecule processes in parallel mode
 
     It is currently only available for use with the Docker driver.
 
-It is possible to run Molecule processes in parallel using another tool to
-orchestrate the parallelization (such as `GNU Parallel`_ or `Pytest`_).
-
 When Molecule receives the ``--parallel`` flag it will generate a `UUID`_ for
 the duration of the testing sequence and will use that unique identifier to
 cache the run-time state for that process. The parallel Molecule processes
@@ -397,6 +394,12 @@ other.
 Molecule uses a new and separate caching folder for this in the
 ``$HOME/.cache/molecule_parallel`` location. Molecule exposes a new environment
 variable ``MOLECULE_PARALLEL`` which can enable this functionality.
+
+It is possible to run Molecule processes in parallel using another tool to
+orchestrate the parallelization (such as `GNU Parallel`_ or `Pytest`_).
+If you do so, make sure Molecule knows it is running in parallel mode by
+specifying the ``--parallel`` flag to your command(s) to avoid concurrency
+issues.
 
 .. _GNU Parallel: https://www.gnu.org/software/parallel/
 .. _Pytest: https://docs.pytest.org/en/latest/

--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -65,9 +65,9 @@ class Check(base.Base):
         Load an env file to read variables from when rendering
         molecule.yml.
 
-    .. program:: molecule --parallel check
+    .. program:: molecule check --parallel
 
-    .. option:: molecule --parallel check
+    .. option:: molecule check --parallel
 
        Run in parallelizable mode.
     """

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -79,9 +79,9 @@ class Destroy(base.Base):
         Load an env file to read variables from when rendering
         molecule.yml.
 
-    .. program:: molecule --parallel destroy
+    .. program:: molecule destroy --parallel
 
-    .. option:: molecule --parallel destroy
+    .. option:: molecule destroy --parallel
 
        Run in parallelizable mode.
     """

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -79,9 +79,9 @@ class Test(base.Base):
         Load an env file to read variables from when rendering
         molecule.yml.
 
-    .. program:: molecule --parallel test
+    .. program:: molecule test --parallel
 
-    .. option:: molecule --parallel test
+    .. option:: molecule test --parallel
 
        Run in parallelizable mode.
     """


### PR DESCRIPTION
Hello,

I recently had the need to run Molecule tests in parallel mode using another tool (https://github.com/ovh/venom to be specific), and found some errors/typos in the docs. 
I also added the line about running the molecule command with the --parallel flag to be more explicit on how to avoid concurrency issues (mine was over apt lock :smile: ).

#### PR Type
- Docs Pull Request
