### PR TITLE
Allow docker mounts parameter in molecule.yml

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -131,6 +131,7 @@
         security_opts: "{{ item.security_opts | default(omit) }}"
         devices: "{{ item.devices | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
+        mounts: "{{ item.mounts | default(omit) }}"
         tmpfs: "{{ item.tmpfs | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"
         sysctls: "{{ item.sysctls | default(omit) }}"


### PR DESCRIPTION
Mounts are supported by the Ansible docker_container plugin but are not passed along if specified for a platform in molecule.yml. Mounts are more powerful and specific than volumes. They can, for example, be used to mount a network file share at container startup (which is my use case). This is a one liner fix to make mounts work in the Stable/3.0.2 branch. It simply passes them along in create.yml like the other options. I have tested it quite informally by mounting an nfs share from my organization:

```
# molecule.yml
driver:
  name: docker
platforms:
  - name: lab-ioc-deploy-default
    image: registry.esss.lu.se/ics-docker/centos-systemd:7
    # SYS_ADMIN required to run systemctl
    capabilities:
      - SYS_ADMIN
    interactive: yes
    tty: yes
    volumes:
      - /sys/fs/cgroup:/sys/fs/cgroup:ro
    mounts:
      - type: volume
        source: epics
        target: /epics
        read_only: yes
        volume_driver: local
        volume_options:
          type: nfs
          device: ":/e3"
          o: "addr=e3-share-lab.cslab.esss.lu.se,nolock,ro"
    tmpfs:
      - /run
    command: /sbin/init
    groups:
      - molecule_group
```
```
# test it out
molecule create
docker exec -it lab-ioc-deploy-default /bin/sh
sh-4.2# ls /epics/
base-7.0.3.1  base-7.0.4
# success!
```

PR Type
Bugfix Pull Request (maybe it was a bug that mounts was left out)
Feature Pull Request (add mounts)