### PR TITLE
Allow external drivers to have their own embedded playbooks

### DIFF
--- a/molecule/provisioner/ansible_playbooks.py
+++ b/molecule/provisioner/ansible_playbooks.py
@@ -110,11 +110,22 @@ class AnsiblePlaybooks(object):
                 return playbook
 
     def _get_bundled_driver_playbook(self, section):
-        return self._config.driver.get_playbook(section) or os.path.join(
+        path = self._config.driver.get_playbook(section)
+        if path:
+            return path
+        path = os.path.join(
             self._get_playbook_directory(),
             self._config.driver.name,
             self._config.config["provisioner"]["playbooks"][section],
         )
+        if os.path.exists(path):
+            return path
+        path = os.path.join(
+            self._config.driver._path,
+            "playbooks",
+            self._config.config["provisioner"]["playbooks"][section],
+        )
+        return path
 
     def _normalize_playbook(self, playbook):
         """

--- a/molecule/test/unit/provisioner/test_ansible_playbooks.py
+++ b/molecule/test/unit/provisioner/test_ansible_playbooks.py
@@ -137,6 +137,6 @@ def test_get_ansible_playbook_with_driver_key_when_playbook_key_missing(
 def test_get_bundled_driver_playbook(_instance):
     result = _instance._get_bundled_driver_playbook("create")
     parts = pytest.helpers.os_split(result)
-    x = ("ansible", "playbooks", "delegated", "create.yml")
+    x = ("molecule", "driver", "playbooks", "create.yml")
 
     assert x == parts[-4:]


### PR DESCRIPTION
Fixes bug where external driver playbooks were not looked for.
