### PR TITLE
Finalize Ansible python package dependency decoupling

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,6 +36,18 @@ Pip
 
 :std:doc:`pip <pip:usage>` is the only supported installation method.
 
+.. warning::
+
+  Ansible is not listed as a direct dependency of molecule package because
+  we only call it as a command line tool. You may want to install it
+  using your distribution package installer. If you want to also install a
+  compatible  version of ansible, make use of provided ``ansible`` or
+  ``ansible-base`` extras:
+
+  .. code-block:: bash
+
+      $ python3 -m pip install "molecule[ansible]"  # or molecule[ansible-base]
+
 Keep in mind that on selinux supporting systems, if you install into a virtual
 environment, you may face :gh:`issue <ansible/ansible/issues/34340>` even
 if selinux is not enabled or is configured to be permissive.

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -20,15 +20,18 @@
 """Config Module."""
 
 import os
+import subprocess
+import sys
 from uuid import uuid4
 
-import pkg_resources
+from packaging.version import Version
 
 from molecule import api, interpolation, logger, platforms, scenario, state, util
+from molecule.constants import RC_SETUP_ERROR
 from molecule.dependency import ansible_galaxy, shell
 from molecule.model import schema_v3
 from molecule.provisioner import ansible
-from molecule.util import boolean
+from molecule.util import boolean, lru_cache
 
 LOG = logger.get_logger(__name__)
 MOLECULE_DEBUG = boolean(os.environ.get("MOLECULE_DEBUG", "False"))
@@ -96,20 +99,10 @@ class Config(object, metaclass=NewInitCaller):
         util.write_file(self.config_file, util.safe_dump(self.config))
 
     @property
-    def ansible_version(self):
-        """Return current version of ansible."""
-        try:
-            ansible_version = pkg_resources.get_distribution("ansible-base").version
-        except Exception:
-            ansible_version = pkg_resources.get_distribution("ansible").version
-
-        return pkg_resources.parse_version(ansible_version)
-
-    @property
     def ansible_collections_path(self):
         """Return collection path variable for current version of Ansible."""
         # https://github.com/ansible/ansible/pull/70007
-        if self.ansible_version >= pkg_resources.parse_version("2.10.0.dev0"):
+        if ansible_version() >= ansible_version("2.10.0.dev0"):
             return "ANSIBLE_COLLECTIONS_PATH"
         else:
             return "ANSIBLE_COLLECTIONS_PATHS"
@@ -453,3 +446,31 @@ def set_env_from_file(env, env_file):
         return env
 
     return env
+
+
+@lru_cache()
+def ansible_version(version: str = None) -> Version:
+    """Return current Version object for Ansible.
+
+    If version is not mentioned, it returns current version as detected.
+    When version argument is mentioned, it return converts the version string
+    to Version object in order to make it usable in comparisons.
+    """
+    if not version:
+        try:
+            version = (
+                subprocess.run(
+                    ["ansible", "--version"],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    universal_newlines=True,
+                )
+                .stdout.splitlines()[0]
+                .split()[1]
+            )
+        except FileNotFoundError:
+            LOG.fatal(
+                "Unable to find ansible executable. Read https://molecule.readthedocs.io/en/latest/installation.html"
+            )
+            sys.exit(RC_SETUP_ERROR)
+    return Version(version)

--- a/molecule/constants.py
+++ b/molecule/constants.py
@@ -3,5 +3,6 @@
 
 RC_SUCCESS = 0
 RC_TIMEOUT = 3
+RC_SETUP_ERROR = 4  # Broken setup, like missing Ansible
 
 MOLECULE_HEADER = "# Molecule managed"

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -19,7 +19,6 @@
 #  DEALINGS IN THE SOFTWARE.
 """Molecule Shell Module."""
 
-import subprocess
 import sys
 from functools import lru_cache
 
@@ -32,7 +31,7 @@ from click_help_colors import _colorize
 import molecule
 from molecule import command
 from molecule.command.base import click_group_ex
-from molecule.config import MOLECULE_DEBUG
+from molecule.config import MOLECULE_DEBUG, ansible_version
 from molecule.logger import should_do_markup
 from molecule.util import lookup_config_file
 
@@ -52,22 +51,10 @@ def _version_string() -> str:
     color = "bright_yellow" if v.is_prerelease else "green"  # type: ignore
     msg = "molecule %s\n" % _colorize(molecule.__version__, color)
 
-    # extract ansible from the command line
-    ansible_version = (
-        subprocess.run(
-            ["ansible", "--version"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-        )
-        .stdout.splitlines()[0]
-        .split()[1]
-    )
-
     msg += _colorize(
         "   ansible==%s python==%s.%s"
         % (
-            ansible_version,
+            ansible_version(),
             sys.version_info[0],
             sys.version_info[1],
         ),

--- a/molecule/test/functional/conftest.py
+++ b/molecule/test/functional/conftest.py
@@ -30,6 +30,7 @@ import pytest
 import sh
 
 from molecule import logger, util
+from molecule.config import ansible_version
 from molecule.test.conftest import change_dir_to
 
 LOG = logger.get_logger(__name__)
@@ -270,14 +271,6 @@ def supports_docker():
     return True
 
 
-def min_ansible(version):
+def min_ansible(version: str) -> bool:
     """Ensure current Ansible is newer than a given a minimal one."""
-    try:
-        from ansible.release import __version__
-
-        return pkg_resources.parse_version(__version__) >= pkg_resources.parse_version(
-            version
-        )
-    except ImportError as exception:
-        LOG.error("Unable to parse Ansible version", exc_info=exception)
-        return False
+    return ansible_version() >= ansible_version(version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ install_requires =
     colorama >= 0.3.9
     cookiecutter >= 1.6.0, != 1.7.1
     Jinja2 >= 2.10.1
+    packaging
     paramiko >= 2.5.0, < 3
     pexpect >= 4.6.0, < 5
     pluggy >= 0.7.1, < 1.0
@@ -87,6 +88,10 @@ install_requires =
     selinux; sys_platform=="linux"
 
 [options.extras_require]
+ansible =
+    ansible >= 2.10
+ansible-base =
+    ansible-base >= 2.10
 docs =
     simplejson
     Sphinx
@@ -98,13 +103,12 @@ podman =
 windows =
     pywinrm
 test =
-    ansible >= 2.8  # keep it N/N-1
+    ansible >= 2.9  # keep it N/N-1
 
     ansi2html
     coverage < 5  # https://github.com/pytest-dev/pytest-cov/issues/250
 
     mock>=3.0.5, < 4
-    packaging
     pytest-cov>=2.7.1, < 3
     pytest-helpers-namespace>=2019.1.8, < 2020
     pytest-html>=1.21.0


### PR DESCRIPTION
Molecule no longer imports any Ansible internals during runtime or testing.

Completes: https://github.com/ansible-community/molecule/pull/2805