### PR TITLE
Relaxed test extra dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -103,20 +103,21 @@ podman =
 windows =
     pywinrm
 test =
+    # do not add ceiling unless we have known bugs
     ansible >= 2.9  # keep it N/N-1
 
     ansi2html
     coverage < 5  # https://github.com/pytest-dev/pytest-cov/issues/250
 
-    mock>=3.0.5, < 4
-    pytest-cov>=2.7.1, < 3
-    pytest-helpers-namespace>=2019.1.8, < 2020
+    mock>=3.0.5
+    pytest-cov>=2.7.1
+    pytest-helpers-namespace>=2019.1.8
     pytest-html>=1.21.0
-    pytest-mock>=1.10.4, < 2
-    pytest-verbose-parametrize>=1.7.0, < 2
+    pytest-mock>=1.10.4
+    pytest-verbose-parametrize>=1.7.0
     pytest-plus
-    pytest-xdist>=1.29.0, < 2
-    pytest>=5.4.0, < 5.5
+    pytest-xdist>=1.29.0
+    pytest>=5.4.0
     testinfra >= 3.4.0
 lint =
     ansible-lint >= 4.2.0, < 5


### PR DESCRIPTION
Avoid potential dependency conflicts when using test extras. One such example was that pytest-xdist had newer versions, while it was still compatible.