### PR TITLE
Avoid implicit gather_facts on verify

### DIFF
--- a/molecule/cookiecutter/scenario/verifier/ansible/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule/cookiecutter/scenario/verifier/ansible/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -4,6 +4,7 @@
 {% raw -%}
 - name: Verify
   hosts: all
+  gather_facts: false
   tasks:
   - name: Example assertion
     assert:


### PR DESCRIPTION
Disable gather_facts for verify playbook as is may not be required in practice.

This also makes it possible to test molecule-podman by creating a workaround for know bug.

Related: https://github.com/ansible-community/molecule-podman/issues/2
