### PR TITLE
Added ansible-lint to test extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -105,6 +105,7 @@ windows =
 test =
     # do not add ceiling unless we have known bugs
     ansible >= 2.9  # keep it N/N-1
+    ansible-lint >= 4.3.5  # used during functional testing
 
     ansi2html
     coverage < 5  # https://github.com/pytest-dev/pytest-cov/issues/250


### PR DESCRIPTION
Makes it easier to reuse test extras of molecule for testing its plugins, especially as ansible-lint is used during functional testing.

