### PR TITLE
Include driver information alongside version

### DIFF
--- a/lib/molecule/driver/base.py
+++ b/lib/molecule/driver/base.py
@@ -23,6 +23,8 @@ import abc
 import inspect
 import os
 
+import pkg_resources
+
 import molecule
 from molecule.status import Status
 
@@ -41,6 +43,8 @@ class Driver(object):
         """
         self._config = config
         self._path = os.path.abspath(os.path.dirname(inspect.getfile(self.__class__)))
+        self.module = self.__module__.split(".")[0]
+        self.version = pkg_resources.get_distribution(self.module).version
 
     @property  # type: ignore
     @abc.abstractmethod

--- a/lib/molecule/shell.py
+++ b/lib/molecule/shell.py
@@ -30,6 +30,7 @@ from click_help_colors import _colorize
 
 import molecule
 from molecule import command
+from molecule.api import drivers
 from molecule.command.base import click_group_ex
 from molecule.config import MOLECULE_DEBUG, ansible_version
 from molecule.logger import should_do_markup
@@ -51,15 +52,10 @@ def _version_string() -> str:
     color = "bright_yellow" if v.is_prerelease else "green"  # type: ignore
     msg = "molecule %s\n" % _colorize(molecule.__version__, color)
 
-    msg += _colorize(
-        "   ansible==%s python==%s.%s"
-        % (
-            ansible_version(),
-            sys.version_info[0],
-            sys.version_info[1],
-        ),
-        "bright_black",
-    )
+    details = f"    ansible:{ansible_version()} python:{sys.version_info[0]}.{sys.version_info[1]}"
+    for driver in drivers():
+        details += f"\n    {driver}:{driver.version} from {driver.module}"
+    msg += _colorize(details, "bright_black")
     return msg
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ install_requires =
     pluggy >= 0.7.1, < 1.0
     PyYAML >= 5.1, < 6
     sh >= 1.13.1, < 1.14
+    setuptools >= 42 # for pkg_resources
     tabulate >= 0.8.4
     tree-format >= 0.1.2
     yamllint >= 1.15.0, < 2


### PR DESCRIPTION
Dumps driver information when printing version, making easier to debug.

Example:
![](https://sbarnea.com/ss/Screen-Shot-2020-10-19-13-46-58.00.png)