### PR TITLE
Avoid building molecule container with version 0.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ ADD . .
 
 RUN \
 python3 -m pip wheel \
--w dist --no-build-isolation \
+-w dist \
 ".[${MOLECULE_EXTRAS}]" testinfra ${MOLECULE_PLUGINS}
 
 RUN ls -1 dist/


### PR DESCRIPTION
Avoids bug in pip/wheel that installs molecule with version 0.0.0 inside the container.