### PR TITLE
Remove coverage ceiling from test extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,6 @@ test =
     ansible-lint >= 4.3.5  # used during functional testing
 
     ansi2html
-    coverage < 5  # https://github.com/pytest-dev/pytest-cov/issues/250
 
     mock>=3.0.5
     pytest-cov>=2.7.1


### PR DESCRIPTION
Avoid potential installation conflicts due to coverage ceiling.