### PR TITLE
Remove dependency on tree-format

### DIFF
--- a/lib/molecule/scenarios.py
+++ b/lib/molecule/scenarios.py
@@ -18,11 +18,6 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 """Scenarios Module."""
-
-import operator
-
-import tree_format
-
 from molecule import logger, util
 
 LOG = logger.get_logger(__name__)
@@ -75,24 +70,10 @@ class Scenarios(object):
         msg = "Test matrix"
         LOG.info(msg)
 
-        tree = tuple(
-            (
-                "",
-                [
-                    (scenario.name, [(action, []) for action in scenario.sequence])
-                    for scenario in self.all
-                ],
-            )
-        )
-
-        tf = tree_format.format_tree(
-            tree,
-            format_node=operator.itemgetter(0),
-            get_children=operator.itemgetter(1),
-        )
-
-        LOG.out(tf)
-        LOG.out("")
+        tree = {}
+        for scenario in self.all:
+            tree[scenario.name] = [action for action in scenario.sequence]
+        util.print_as_yaml(tree)
 
     def _verify(self):
         """

--- a/lib/molecule/test/unit/test_scenarios.py
+++ b/lib/molecule/test/unit/test_scenarios.py
@@ -23,7 +23,8 @@ import copy
 
 import pytest
 
-from molecule import config, scenario, scenarios
+from molecule import config, scenario, scenarios, util
+from molecule.console import console
 
 
 @pytest.fixture
@@ -73,44 +74,41 @@ def test_all_filters_on_scenario_name_property(_instance):
     assert 1 == len(_instance.all)
 
 
-def test_print_matrix(mocker, patched_logger_info, patched_logger_out, _instance):
-    _instance.print_matrix()
+def test_print_matrix(capsys, _instance):
+    with console.capture() as capture:
+        _instance.print_matrix()
+    result = util.chomp(util.strip_ansi_escape(capture.get()))
 
-    msg = "Test matrix"
-    patched_logger_info(msg)
-
-    matrix_out = u"""
-├── default
-│   ├── dependency
-│   ├── lint
-│   ├── cleanup
-│   ├── destroy
-│   ├── syntax
-│   ├── create
-│   ├── prepare
-│   ├── converge
-│   ├── idempotence
-│   ├── side_effect
-│   ├── verify
-│   ├── cleanup
-│   └── destroy
-└── foo
-    ├── dependency
-    ├── lint
-    ├── cleanup
-    ├── destroy
-    ├── syntax
-    ├── create
-    ├── prepare
-    ├── converge
-    ├── idempotence
-    ├── side_effect
-    ├── verify
-    ├── cleanup
-    └── destroy
-"""
-    assert matrix_out == patched_logger_out.mock_calls[0][1][0]
-    assert mocker.call("") == patched_logger_out.mock_calls[1]
+    matrix_out = u"""---
+default:
+  - dependency
+  - lint
+  - cleanup
+  - destroy
+  - syntax
+  - create
+  - prepare
+  - converge
+  - idempotence
+  - side_effect
+  - verify
+  - cleanup
+  - destroy
+foo:
+  - dependency
+  - lint
+  - cleanup
+  - destroy
+  - syntax
+  - create
+  - prepare
+  - converge
+  - idempotence
+  - side_effect
+  - verify
+  - cleanup
+  - destroy"""
+    assert matrix_out in result
 
 
 def test_verify_does_not_raise_when_found(_instance):

--- a/lib/molecule/util.py
+++ b/lib/molecule/util.py
@@ -34,8 +34,10 @@ from typing import Any, Dict, List, Optional, Union
 import colorama
 import jinja2
 import yaml
+from rich.syntax import Syntax
 from subprocess_tee import run
 
+from molecule.console import console
 from molecule.constants import MOLECULE_HEADER
 from molecule.logger import get_logger
 
@@ -442,3 +444,14 @@ def dict2args(data: Dict) -> List[str]:
 def bool2args(data: bool) -> List[str]:
     """Convert a boolean value to command line argument (flag)."""
     return []
+
+
+def print_as_yaml(data: Any) -> None:
+    """Render python object as yaml on console."""
+    result = Syntax(safe_dump(data), "yaml")
+    console.print(result)
+
+
+def chomp(text: str) -> str:
+    """Remove any training spaces from string."""
+    return "\n".join([x.rstrip() for x in text.splitlines()])

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,6 @@ install_requires =
     rich >= 6.0
     subprocess-tee >= 0.1.2
     setuptools >= 42 # for pkg_resources
-    tree-format >= 0.1.2
     yamllint >= 1.15.0, < 2
     # selinux python module is needed as least by ansible-docker/podman modules
     # and allows us of isolated (default) virtualenvs. It does not avoid need


### PR DESCRIPTION
Replaces our limited use of tree-format with a simple YAML dump for printing the matrix steps.

This changes the output a little bit, the new one looks like:

![](https://sbarnea.com/ss/Screen-Shot-2020-10-27-16-40-00.39.png)
