### PR TITLE
Move pexpect from a runtime dependency to test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ py3-mccabe \
 py3-netifaces \
 py3-paramiko \
 py3-pbr \
-py3-pexpect \
 py3-pip \
 py3-pluggy \
 py3-psutil \
@@ -116,7 +115,6 @@ py3-mccabe \
 py3-netifaces \
 py3-paramiko \
 py3-pbr \
-py3-pexpect \
 py3-pip \
 py3-pluggy \
 py3-psutil \

--- a/lib/molecule/command/login.py
+++ b/lib/molecule/command/login.py
@@ -19,15 +19,10 @@
 #  DEALINGS IN THE SOFTWARE.
 """Login Command Module."""
 
-import fcntl
 import os
-import signal
-import struct
-import sys
-import termios
+from subprocess import run
 
 import click
-import pexpect
 
 from molecule import logger, scenarios, util
 from molecule.command import base
@@ -147,19 +142,8 @@ class Login(base.Base):
         login_options["lines"] = lines
         login_cmd = self._config.driver.login_cmd_template.format(**login_options)
 
-        dimensions = (int(lines), int(columns))
         cmd = "/usr/bin/env {}".format(login_cmd)
-        self._pt = pexpect.spawn(cmd, dimensions=dimensions)
-        signal.signal(signal.SIGWINCH, self._sigwinch_passthrough)
-        self._pt.interact()
-
-    def _sigwinch_passthrough(self, sig, data):  # pragma: no cover
-        tiocgwinsz = 1074295912  # assume
-        if "TIOCGWINSZ" in dir(termios):
-            tiocgwinsz = termios.TIOCGWINSZ
-        s = struct.pack("HHHH", 0, 0, 0, 0)
-        a = struct.unpack("HHHH", fcntl.ioctl(sys.stdout.fileno(), tiocgwinsz, s))
-        self._pt.setwinsize(a[0], a[1])
+        run(cmd, shell=True)
 
 
 @base.click_command_ex()

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,6 @@ install_requires =
     Jinja2 >= 2.10.1
     packaging
     paramiko >= 2.5.0, < 3
-    pexpect >= 4.6.0, < 5
     pluggy >= 0.7.1, < 1.0
     PyYAML >= 5.1, < 6
     rich >= 6.0
@@ -112,6 +111,7 @@ test =
     ansi2html
 
     mock>=3.0.5
+    pexpect >= 4.6.0, < 5
     pytest-cov>=2.7.1
     pytest-helpers-namespace>=2019.1.8
     pytest-html>=1.21.0


### PR DESCRIPTION
We do not really need pexpect as a runtime dependency as it was using only inside login. Using just subprocess.run() seems to work fine, so we can lower our dependencies.


