### PR TITLE
Correct gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ coverage.xml
 pip-wheel-metadata
 docs/docstree
 .docker
-/molecule/
+molecule/**


### PR DESCRIPTION
Fixed wrong git ignore pattern used to exclude a potentially existing molecule folder under the project root.

Previous pattern was confusing git when called with command below, making it believe also lib/molecule was to be excluded.
```
git ls-files --exclude-standard -oi --directory
```

Related: https://git-scm.com/docs/gitignore
