### PR TITLE
Add ecosystem check tox env

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,6 +37,7 @@ jobs:
           - tox_env: py39-devel
             PREFIX: PYTEST_REQPASS=427
           - tox_env: packaging
+          - tox_env: eco
           - tox_env: dockerfile
           - tox_env: build-containers
             needs:
@@ -50,6 +51,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update \
+          && sudo apt-get install -y libvirt-dev
       - name: Find python version
         id: py_ver
         shell: python

--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,9 @@ isolated_build = True
 
 requires =
     # 2020-resolver
-    pip >= 2.20.3
+    pip >= 20.2.4
 
 [testenv]
-# Hotfix for https://github.com/pypa/pip/issues/6434
-# Based on https://github.com/jaraco/skeleton/commit/123b0b2
-# Check https://github.com/tox-dev/tox/issues/1276 for the final solution
-install_command =
-    python -c 'import subprocess, sys; pip_inst_cmd = sys.executable, "-m", "pip", "install"; subprocess.check_call(pip_inst_cmd + ("pip<19.1", )); subprocess.check_call(pip_inst_cmd + tuple(sys.argv[1:]))' {opts} {packages}
 usedevelop = True
 # do not put * in passenv as it may break builds do to reduced isolation
 passenv =
@@ -182,3 +177,28 @@ usedevelop = false
 skip_install = true
 commands =
     sh -c "type snapcraft && snapcraft build"
+
+[testenv:eco]
+description = Smoketest of combining all known to be maintained plugins (ecosystem)
+pip_pre = true
+extras =
+deps =
+    molecule-azure
+    molecule-containers
+    molecule-digitalocean
+    molecule-docker
+    molecule-ec2
+    molecule-gce
+    molecule-libvirt
+    molecule-lxd
+    molecule-openstack
+    molecule-podman
+    molecule-vagrant
+    tox-ansible
+    pipdeptree
+commands =
+    pip check
+    pipdeptree --reverse -e pip,pbr,six,setuptools,toml,urllib3
+    molecule --version
+    molecule drivers
+    # add `molecule doctor` once we implemnt it


### PR DESCRIPTION
Adds an "eco" tox environment that will be used to perform a simple
smoketest of combining all molecule related packages, so we identify
quickly those that cause conflicts or major breakages.
