### PR TITLE
Removed run_command test helper

### DIFF
--- a/lib/molecule/test/conftest.py
+++ b/lib/molecule/test/conftest.py
@@ -25,26 +25,10 @@ import string
 
 import pytest
 
-from molecule import config, logger, util
+from molecule import config, logger
 from molecule.scenario import ephemeral_directory
 
 LOG = logger.get_logger(__name__)
-
-
-@pytest.helpers.register
-def run_command(cmd, env=os.environ, log=True):
-    if cmd.__class__.__name__ == "Command":
-        if log:
-            cmd = _rebake_command(cmd, env)
-
-        # Never let sh truncate exceptions in testing
-        cmd = cmd.bake(_truncate_exc=False)
-
-    return util.run_command(cmd, env=env)
-
-
-def _rebake_command(cmd, env, out=LOG.out, err=LOG.error):
-    return cmd.bake(_env=dict(env), _out=out, _err=err)
 
 
 def is_subset(subset, superset):

--- a/lib/molecule/test/functional/conftest.py
+++ b/lib/molecule/test/functional/conftest.py
@@ -31,6 +31,7 @@ import pytest
 from molecule import logger, util
 from molecule.config import ansible_version
 from molecule.test.conftest import change_dir_to
+from molecule.util import run_command
 
 LOG = logger.get_logger(__name__)
 
@@ -73,7 +74,7 @@ def with_scenario(request, scenario_to_test, driver_name, scenario_name, skip_te
             msg = "CLEANUP: Destroying instances for all scenario(s)"
             LOG.out(msg)
             cmd = ["molecule", "destroy", "--driver-name", driver_name, "--all"]
-            pytest.helpers.run_command(cmd)
+            assert run_command(cmd).returncode == 0
 
 
 @pytest.fixture
@@ -93,13 +94,13 @@ def skip_test(request, driver_name):
 @pytest.helpers.register
 def idempotence(scenario_name):
     cmd = ["molecule", "create", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
     cmd = ["molecule", "converge", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
     cmd = ["molecule", "idempotence", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.helpers.register
@@ -107,12 +108,12 @@ def init_role(temp_dir, driver_name):
     role_directory = os.path.join(temp_dir.strpath, "test-init")
 
     cmd = ["molecule", "init", "role", "test-init", "--driver-name", driver_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
     pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
         cmd = ["molecule", "test", "--all"]
-        pytest.helpers.run_command(cmd)
+        assert run_command(cmd).returncode == 0
 
 
 @pytest.helpers.register
@@ -120,7 +121,7 @@ def init_scenario(temp_dir, driver_name):
     # Create role
     role_directory = os.path.join(temp_dir.strpath, "test-init")
     cmd = ["molecule", "init", "role", "test-init", "--driver-name", driver_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
     pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
@@ -138,12 +139,12 @@ def init_scenario(temp_dir, driver_name):
             "--driver-name",
             driver_name,
         ]
-        pytest.helpers.run_command(cmd)
+        assert run_command(cmd).returncode == 0
 
         assert os.path.isdir(scenario_directory)
 
         cmd = ["molecule", "test", "--scenario-name", "test-scenario", "--all"]
-        pytest.helpers.run_command(cmd)
+        assert run_command(cmd).returncode == 0
 
 
 @pytest.helpers.register
@@ -165,15 +166,15 @@ def metadata_lint_update(role_directory):
     # the customize ansible-lint config is used.
     with change_dir_to(role_directory):
         cmd = ["ansible-lint", "."]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.helpers.register
 def list(x):
     cmd = ["molecule", "list"]
-    out = pytest.helpers.run_command(cmd, log=False)
-    out = out.stdout.decode("utf-8")
-    out = util.strip_ansi_color(out)
+    result = run_command(cmd)
+    assert result.returncode == 0
+    out = util.strip_ansi_color(result.stdout)
 
     for l in x.splitlines():
         assert l in out
@@ -192,10 +193,10 @@ def list_with_format_plain(x):
 @pytest.helpers.register
 def login(login_args, scenario_name="default"):
     cmd = ["molecule", "destroy", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
     cmd = ["molecule", "create", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
     for instance, regexp in login_args:
         if len(login_args) > 1:
@@ -219,19 +220,19 @@ def test(driver_name, scenario_name="default", parallel=False):
         if parallel:
             cmd.append("--parallel")
 
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.helpers.register
 def verify(scenario_name="default"):
     cmd = ["molecule", "create", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
     cmd = ["molecule", "converge", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
     cmd = ["molecule", "verify", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 def get_docker_executable():

--- a/lib/molecule/test/functional/test_command.py
+++ b/lib/molecule/test/functional/test_command.py
@@ -20,7 +20,7 @@
 
 import pytest
 
-from molecule import util
+from molecule.util import run_command
 
 
 @pytest.fixture
@@ -51,7 +51,7 @@ def driver_name(request):
 )
 def test_command_check(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "check", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.mark.extensive
@@ -64,7 +64,7 @@ def test_command_check(scenario_to_test, with_scenario, scenario_name):
 )
 def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "cleanup", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.mark.extensive
@@ -77,7 +77,7 @@ def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
 )
 def test_command_converge(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "converge", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.mark.extensive
@@ -90,7 +90,7 @@ def test_command_converge(scenario_to_test, with_scenario, scenario_name):
 )
 def test_command_create(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "create", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.mark.parametrize(
@@ -103,13 +103,11 @@ def test_command_create(scenario_to_test, with_scenario, scenario_name):
 )
 def test_command_dependency(request, scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "dependency", "--scenario-name", scenario_name]
-    result = util.run_command(cmd, echo=True)
-    assert result.returncode == 0
+    assert run_command(cmd, echo=True).returncode == 0
 
     # Validate that dependency worked by running converge, which make use
     cmd = ["molecule", "converge", "--scenario-name", scenario_name]
-    result = util.run_command(cmd, echo=True)
-    assert result.returncode == 0
+    assert run_command(cmd, echo=True).returncode == 0
 
 
 @pytest.mark.extensive
@@ -120,7 +118,7 @@ def test_command_dependency(request, scenario_to_test, with_scenario, scenario_n
 )
 def test_command_destroy(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "destroy", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.mark.extensive
@@ -155,7 +153,7 @@ def test_command_init_scenario(temp_dir, driver_name, skip_test):
 )
 def test_command_lint(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "lint", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.mark.parametrize(
@@ -199,10 +197,10 @@ def test_command_list_with_format_plain(scenario_to_test, with_scenario, expecte
 )
 def test_command_prepare(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "create", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
     cmd = ["molecule", "prepare", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.mark.extensive
@@ -215,7 +213,7 @@ def test_command_prepare(scenario_to_test, with_scenario, scenario_name):
 )
 def test_command_side_effect(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "side-effect", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.mark.extensive
@@ -228,7 +226,7 @@ def test_command_side_effect(scenario_to_test, with_scenario, scenario_name):
 )
 def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "syntax", "--scenario-name", scenario_name]
-    pytest.helpers.run_command(cmd)
+    assert run_command(cmd).returncode == 0
 
 
 @pytest.mark.parametrize(

--- a/lib/molecule/test/unit/cookiecutter/test_molecule.py
+++ b/lib/molecule/test/unit/cookiecutter/test_molecule.py
@@ -73,4 +73,5 @@ def test_valid(temp_dir, _molecule_file, _role_directory, _command_args, _instan
     assert {} == schema_v3.validate(data)
 
     cmd = ["yamllint", "-s", _molecule_file]
-    pytest.helpers.run_command(cmd)
+    result = util.run_command(cmd)
+    assert result.returncode == 0


### PR DESCRIPTION
As run_command is part of molecule.util, it makes sense to remove the test helper as we no longer need sh baking tricks.

This will prevent silent bugs where we miss to detect an error as the newer run_command does return a result instead of raising an Exception when the subprocess returned any value other than zero.
