### PR TITLE
Harden smoketest to avoid ansible becoming a python dependency

### DIFF
--- a/tools/smoketest.sh
+++ b/tools/smoketest.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+ANSIBLE=$(pipdeptree --reverse -p ansible)
+
+if [ -z "$ANSIBLE" ]; then
+    echo "Ansible dependency not detected."
+else
+    echo "FATAL: Detected unexpected dependency on Ansible package"
+    echo "$ANSIBLE"
+    exit 2
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 3.9.0
+minversion = 3.18.0
 envlist =
     lint
     docs
@@ -34,7 +34,6 @@ passenv =
     TERM
 setenv =
     ANSIBLE_CONFIG={toxinidir}/.ansible.cfg
-    ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
     ANSIBLE_DISPLAY_FAILED_STDERR=1
     ANSIBLE_VERBOSITY=1
     MOLECULE_NO_LOG=0
@@ -68,8 +67,7 @@ commands =
     # html report is used by Zuul CI to display reports
     python -m pytest lib/molecule/test/unit/ {env:_EXTRAS} {env:PYTEST_ADDOPTS:} {posargs}
 
-
-whitelist_externals =
+allowlist_externals =
     find
     rm
     sh
@@ -143,7 +141,7 @@ deps =
 commands_pre =
 commands =
     python ./tools/build-containers.py
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:packaging]
@@ -201,4 +199,6 @@ commands =
     pipdeptree --reverse -e pip,pbr,six,setuptools,toml,urllib3
     molecule --version
     molecule drivers
-    # add `molecule doctor` once we implemnt it
+    bash ./tools/smoketest.sh
+allowlist_externals =
+    bash


### PR DESCRIPTION
Molecule drivers should never made ansible package as a dependency
as molecule itself is decoupled from Ansible python module.

This removes drivers that are prevent this decoupling.

Related: https://github.com/ansible-community/molecule-vagrant/pull/78

