### PR TITLE
Set ansible_ssh_pass with ansible_password because of a testinfra issue

### DIFF
--- a/lib/molecule/driver/delegated.py
+++ b/lib/molecule/driver/delegated.py
@@ -198,6 +198,8 @@ class Delegated(Driver):
                     )
                 if d.get("password", None):
                     conn_dict["ansible_password"] = d.get("password")
+                    # Based on testinfra documentation, ansible password must be passed via ansible_ssh_pass
+                    # issue to fix this can be found https://github.com/philpep/testinfra/issues/580
                     conn_dict["ansible_ssh_pass"] = d.get("password")
                 if d.get("winrm_transport", None):
                     conn_dict["ansible_winrm_transport"] = d.get("winrm_transport")

--- a/lib/molecule/driver/delegated.py
+++ b/lib/molecule/driver/delegated.py
@@ -198,6 +198,7 @@ class Delegated(Driver):
                     )
                 if d.get("password", None):
                     conn_dict["ansible_password"] = d.get("password")
+                    conn_dict["ansible_ssh_pass"] = d.get("password")
                 if d.get("winrm_transport", None):
                     conn_dict["ansible_winrm_transport"] = d.get("winrm_transport")
                 if d.get("winrm_cert_pem", None):

--- a/lib/molecule/driver/delegated.py
+++ b/lib/molecule/driver/delegated.py
@@ -199,7 +199,7 @@ class Delegated(Driver):
                 if d.get("password", None):
                     conn_dict["ansible_password"] = d.get("password")
                     # Based on testinfra documentation, ansible password must be passed via ansible_ssh_pass
-                    # issue to fix this can be found https://github.com/philpep/testinfra/issues/580
+                    # issue to fix this can be found https://github.com/pytest-dev/pytest-testinfra/issues/580
                     conn_dict["ansible_ssh_pass"] = d.get("password")
                 if d.get("winrm_transport", None):
                     conn_dict["ansible_winrm_transport"] = d.get("winrm_transport")


### PR DESCRIPTION
We are using delegated driver to connect to a recently created host on which ssh keys are not set yet, when we had tried to execute molecule test on that it stopped and asked for password in the verify phase even though the password was set in the create.yml.
For verification we use testinfra, under the hood it uses pytest with ansible backend.
After some investigation figured out the reason is that ansible_ssh_pass is not set and based on the doc it is mandatory if key is not set. This [issue](https://github.com/philpep/testinfra/issues/580) has been reported to testinfra, but until it is not fixed this PR implements a small workaround.