### PR TITLE
Avoid duplicate stdout on playbook failures

### DIFF
--- a/lib/molecule/provisioner/ansible_playbook.py
+++ b/lib/molecule/provisioner/ansible_playbook.py
@@ -106,7 +106,10 @@ class AnsiblePlaybook(object):
         self._config.driver.sanity_checks()
         result = util.run_command(self._ansible_command, debug=self._config.debug)
         if result.returncode != 0:
-            util.sysexit_with_message(result.stdout, result.returncode)
+            util.sysexit_with_message(
+                f"Ansible return code was {result.returncode}, command was: {result.args}",
+                result.returncode,
+            )
 
         return result.stdout
 

--- a/lib/molecule/test/unit/provisioner/test_ansible_playbook.py
+++ b/lib/molecule/test/unit/provisioner/test_ansible_playbook.py
@@ -193,7 +193,7 @@ def test_execute_bakes_with_ansible_args(
     assert _instance._ansible_command.cmd == args
 
 
-def test_executes_catches_and_exits_return_code_with_stdout(
+def test_executes_catches_and_exits_return_code(
     patched_run_command, patched_logger_critical, _instance
 ):
     patched_run_command.side_effect = [
@@ -205,9 +205,6 @@ def test_executes_catches_and_exits_return_code_with_stdout(
         _instance.execute()
 
     assert 1 == e.value.code
-
-    msg = "out"
-    patched_logger_critical.assert_called_once_with(msg)
 
 
 def test_add_cli_arg(_instance):


### PR DESCRIPTION
Newer run_command does print stdout/stderr, so there is no need to, print them again in case of failure. We now display the error code and the original command the produced it.

Example output:
```
$ molecule converge                                                                                               [12:55:46]
--> Found config file /Users/ssbarnea/c/a/molecule/.config/molecule/config.yml
--> Test matrix
---
default:
  - dependency
  - create
  - prepare
  - converge
--> Scenario: 'default'
--> Action: 'dependency'
Skipping, missing the requirements file.
Skipping, missing the requirements file.
--> Scenario: 'default'
--> Action: 'create'
Skipping, instances already created.
--> Scenario: 'default'
--> Action: 'prepare'
Skipping, prepare playbook not configured.
--> Scenario: 'default'
--> Action: 'converge'

PLAY [Converge] ****************************************************************

TASK [Gathering Facts] *********************************************************
fatal: [localhost]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: root@localhost: Permission denied (publickey,password,keyboard-interactive).", "unreachable": true}

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0

ERROR: Ansible return code was 4, command was ansible-playbook --inventory /Users/ssbarnea/.cache/molecule/molecule/default/inventory --skip-tags molecule-notest,notest /Users/ssbarnea/c/a/molecule/molecule/default/converge.yml
Time: 0h:00m:03s
```