### PR TITLE
Display scenario and action on a single log line

### DIFF
--- a/lib/molecule/command/base.py
+++ b/lib/molecule/command/base.py
@@ -55,10 +55,12 @@ class Base(object, metaclass=abc.ABCMeta):
         pass
 
     def print_info(self):
-        msg = "Scenario: '{}'".format(self._config.scenario.name)
-        LOG.info(msg)
-        msg = "Action: '{}'".format(util.underscore(self.__class__.__name__))
-        LOG.info(msg)
+        LOG.info(
+            "Running [scenario]%s[/] > [action]%s[/]",
+            self._config.scenario.name,
+            util.underscore(self.__class__.__name__),
+            extra={"markup": True},
+        )
 
     def _setup(self):
         """

--- a/lib/molecule/console.py
+++ b/lib/molecule/console.py
@@ -4,6 +4,17 @@ import sys
 from typing import Any
 
 from rich.console import Console
+from rich.theme import Theme
+
+theme = Theme(
+    {
+        "info": "dim cyan",
+        "warning": "magenta",
+        "danger": "bold red",
+        "scenario": "green",
+        "action": "green",
+    }
+)
 
 
 # Based on Ansible implementation
@@ -41,4 +52,4 @@ def should_do_markup() -> bool:
     return sys.stdout.isatty() and os.environ.get("TERM") != "dumb"
 
 
-console = Console(force_terminal=should_do_markup())
+console = Console(force_terminal=should_do_markup(), theme=theme)

--- a/lib/molecule/test/unit/command/test_base.py
+++ b/lib/molecule/test/unit/command/test_base.py
@@ -96,8 +96,10 @@ def test_init_calls_setup(_patched_base_setup, _instance):
 
 def test_print_info(mocker, patched_logger_info, _instance):
     _instance.print_info()
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'extended_base'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "extended_base" in args
 
 
 def test_setup(

--- a/lib/molecule/test/unit/command/test_check.py
+++ b/lib/molecule/test/unit/command/test_check.py
@@ -41,7 +41,7 @@ def test_execute(
     c = check.Check(config_instance)
     c.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'check'")]
-    assert x == patched_logger_info.mock_calls
-
-    _patched_ansible_check.assert_called_once_with()
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "check" in args

--- a/lib/molecule/test/unit/command/test_cleanup.py
+++ b/lib/molecule/test/unit/command/test_cleanup.py
@@ -55,8 +55,9 @@ def test_execute(
     cu = cleanup.Cleanup(config_instance)
     cu.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'cleanup'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "cleanup" in args
 
     _patched_ansible_cleanup.assert_called_once_with()
 

--- a/lib/molecule/test/unit/command/test_converge.py
+++ b/lib/molecule/test/unit/command/test_converge.py
@@ -37,8 +37,10 @@ def test_execute(
     c = converge.Converge(config_instance)
     c.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'converge'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "converge" in args
 
     patched_ansible_converge.assert_called_once_with()
 

--- a/lib/molecule/test/unit/command/test_create.py
+++ b/lib/molecule/test/unit/command/test_create.py
@@ -42,8 +42,10 @@ def test_execute(
     c = create.Create(config_instance)
     c.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'create'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "converge" in args
 
     assert "delegated" == config_instance.state.driver
 

--- a/lib/molecule/test/unit/command/test_dependency.py
+++ b/lib/molecule/test/unit/command/test_dependency.py
@@ -34,7 +34,9 @@ def test_execute(
     d = dependency.Dependency(config_instance)
     d.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'dependency'")]
-    assert x == patched_logger_info.mock_calls
-
     patched_ansible_galaxy.assert_called_once_with()
+
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "dependency" in args

--- a/lib/molecule/test/unit/command/test_destroy.py
+++ b/lib/molecule/test/unit/command/test_destroy.py
@@ -47,8 +47,11 @@ def test_execute(
     d = destroy.Destroy(config_instance)
     d.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'destroy'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "destroy" in args
+
+    assert "verify" in args
 
     _patched_ansible_destroy.assert_called_once_with()
 

--- a/lib/molecule/test/unit/command/test_idempotence.py
+++ b/lib/molecule/test/unit/command/test_idempotence.py
@@ -48,8 +48,10 @@ def test_execute(
 ):
     _instance.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'idempotence'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "idempotence" in args
 
     patched_ansible_converge.assert_called_once_with(out=None, err=None)
 

--- a/lib/molecule/test/unit/command/test_lint.py
+++ b/lib/molecule/test/unit/command/test_lint.py
@@ -32,5 +32,6 @@ def test_execute(
     l = lint.Lint(config_instance)
     l.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'lint'")]
-    assert x in patched_logger_info.mock_calls
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "lint" in args

--- a/lib/molecule/test/unit/command/test_prepare.py
+++ b/lib/molecule/test/unit/command/test_prepare.py
@@ -47,8 +47,10 @@ def test_execute(
     p = prepare.Prepare(config_instance)
     p.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'prepare'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "prepare" in args
 
     _patched_ansible_prepare.assert_called_once_with()
 

--- a/lib/molecule/test/unit/command/test_side_effect.py
+++ b/lib/molecule/test/unit/command/test_side_effect.py
@@ -62,8 +62,10 @@ def test_execute(
     se = side_effect.SideEffect(config_instance)
     se.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'side_effect'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "side_effect" in args
 
     _patched_ansible_side_effect.assert_called_once_with()
 

--- a/lib/molecule/test/unit/command/test_syntax.py
+++ b/lib/molecule/test/unit/command/test_syntax.py
@@ -41,7 +41,9 @@ def test_execute(
     s = syntax.Syntax(config_instance)
     s.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'syntax'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "syntax" in args
 
     _patched_ansible_syntax.assert_called_once_with()

--- a/lib/molecule/test/unit/command/test_verify.py
+++ b/lib/molecule/test/unit/command/test_verify.py
@@ -34,5 +34,7 @@ def test_execute(
     v = verify.Verify(config_instance)
     v.execute()
 
-    x = [mocker.call("Scenario: 'default'"), mocker.call("Action: 'verify'")]
-    assert x == patched_logger_info.mock_calls
+    assert len(patched_logger_info.mock_calls) == 1
+    name, args, kwargs = patched_logger_info.mock_calls[0]
+    assert "default" in args
+    assert "verify" in args


### PR DESCRIPTION
Change output of executed scenario and action to fit on a single log line, reducing the amount of console output.

![example](https://sbarnea.com/ss/Screen-Shot-2020-10-31-09-20-47.58.png)