### PR TITLE
Make use of internal run_command

### DIFF
--- a/lib/molecule/command/init/role.py
+++ b/lib/molecule/command/init/role.py
@@ -20,8 +20,6 @@
 """Base class used by init role command."""
 
 import os
-import subprocess
-from subprocess import check_output
 
 import click
 
@@ -70,12 +68,12 @@ class Role(base.Base):
             )
             util.sysexit_with_message(msg)
 
-        try:
-            cmd = ["ansible-galaxy", "init", "-v", "--offline", role_name]
-            check_output(cmd, stderr=subprocess.STDOUT, universal_newlines=True)
-        except Exception as e:
+        cmd = ["ansible-galaxy", "init", "-v", "--offline", role_name]
+        result = util.run_command(cmd)
+
+        if result.returncode != 0:
             util.sysexit_with_message(
-                "Galaxy failed to create role: %s: %s" % (e, e.output)
+                "Galaxy failed to create role, returned %s" % result.returncode
             )
 
         scenario_base_directory = os.path.join(role_directory, role_name)

--- a/lib/molecule/command/lint.py
+++ b/lib/molecule/command/lint.py
@@ -20,7 +20,6 @@
 """Lint Command Module."""
 
 import os
-from subprocess import run
 
 import click
 
@@ -96,17 +95,11 @@ class Lint(base.Base):
             )
             util.sysexit_with_message(msg)
 
-        try:
-            LOG.info("Executing: %s" % cmd)
-            run(
-                cmd,
-                env=self.env,
-                shell=True,
-                universal_newlines=True,
-                check=True,
+        result = util.run_command(cmd, env=self.env, echo=True)
+        if result.returncode != 0:
+            util.sysexit_with_message(
+                "Lint failed with error code %s" % result.returncode
             )
-        except Exception as e:
-            util.sysexit_with_message("Lint failed: %s: %s" % (e, e))
 
 
 @base.click_command_ex()

--- a/lib/molecule/config.py
+++ b/lib/molecule/config.py
@@ -21,7 +21,6 @@
 
 import os
 import subprocess
-import sys
 from uuid import uuid4
 
 from packaging.version import Version
@@ -31,7 +30,7 @@ from molecule.constants import RC_SETUP_ERROR
 from molecule.dependency import ansible_galaxy, shell
 from molecule.model import schema_v3
 from molecule.provisioner import ansible
-from molecule.util import boolean, lru_cache
+from molecule.util import boolean, lru_cache, sysexit
 
 LOG = logger.get_logger(__name__)
 MOLECULE_DEBUG = boolean(os.environ.get("MOLECULE_DEBUG", "False"))
@@ -473,5 +472,5 @@ def ansible_version(version: str = None) -> Version:
             LOG.fatal(
                 "Unable to find ansible executable. Read https://molecule.readthedocs.io/en/latest/installation.html"
             )
-            sys.exit(RC_SETUP_ERROR)
+            sysexit(RC_SETUP_ERROR)
     return Version(version)

--- a/lib/molecule/util.py
+++ b/lib/molecule/util.py
@@ -29,7 +29,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import lru_cache  # noqa
 from subprocess import CompletedProcess
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, NoReturn, Optional, Union
 
 import jinja2
 import yaml
@@ -81,7 +81,7 @@ def print_environment_vars(env: Optional[Dict[str, str]]) -> None:
         print()
 
 
-def sysexit(code: int = 1) -> None:
+def sysexit(code: int = 1) -> NoReturn:
     """Perform a system exit with given code, default 1."""
     sys.exit(code)
 


### PR DESCRIPTION
- make lint use run_command
- make galaxy init role use run_command

This allows use to capture the output while still printing it in real time. This is needed as it
will allow us to implement the record functionality for console.