### PR TITLE
Remove debug message about schema validation

### DIFF
--- a/lib/molecule/config.py
+++ b/lib/molecule/config.py
@@ -421,9 +421,6 @@ class Config(object, metaclass=NewInitCaller):
             msg = f"Failed to validate {self.molecule_file}\n\n{errors}"
             util.sysexit_with_message(msg)
 
-        msg = "Validation completed successfully."
-        LOG.debug(msg)
-
 
 def molecule_directory(path):
     """Return directory of the current scenario."""

--- a/lib/molecule/test/unit/test_config.py
+++ b/lib/molecule/test/unit/test_config.py
@@ -300,7 +300,7 @@ def test_validate(
 
     config_instance._validate()
 
-    assert patched_logger_debug.call_count == 2
+    assert patched_logger_debug.call_count == 1
 
     m.assert_called_with(config_instance.config)
 


### PR DESCRIPTION
Removed debug message printed at the end of the validation for each scenario. This spammed output and it is not really needed because we already print when we start validation and if it fails.

This printed message for all scenarios, all the time, so had a big impact for those having multiple scenarios.