### PR TITLE
Fix indentation of example gitlab-ci configuration

### DIFF
--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -157,8 +157,8 @@ Here is another example using Docker, virtualenv and tags on Centos 7.
       stage: test
       tags:
         - molecule-jobs
-    script:
-      - molecule test
+      script:
+        - molecule test
 
 Jenkins Pipeline
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Hello,

I noticed that the indentation of one of the gitlab-ci examples in the docs was wrong for the `script` key so in this pull request i'm fixing it. If you look at the docs as they are right now the first gitlab-ci example is correctly indented but the other one (which is the one I'm fixing) isn't.

Testing done:

- Executed `tox -e docs` and verified that the generated html files had the indentation issue fixed.

I signed off my commits as it's recommended in the Contributors guidelines and I think I'm not forgetting something mentioned in there but please let me know if i am and I'll gladly correct it.

Thanks.