### PR TITLE
Documentation: Remove extra empty line in Drivers section

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -66,7 +66,6 @@ any provider `Ansible`_ supports.  This work is offloaded to the `provisioner`.
 
 The driver's name is specified in `molecule.yml`, and can be overridden on the
 command line.  Molecule will remember the last successful driver used, and
-
 continue to use the driver for all subsequent subcommands, or until the
 instances are destroyed by Molecule.
 


### PR DESCRIPTION
Hello,

While reading the Drivers section of the documentation I noticed that there's an extra empty line that was causing what is supposed to be a single paragraph to be rendered as two paragraphs, as seen below:

![image](https://user-images.githubusercontent.com/9064060/97788188-d0ace180-1b95-11eb-8c78-7d311e4d7d22.png)

I believe that this is not intentional (if it is do let me know and we can close this pull request) so in this pull request I'm submitting a simple change that removes that empty line and thus the paragraph is rendered correctly:

![image](https://user-images.githubusercontent.com/9064060/97788208-0c47ab80-1b96-11eb-87f6-648df8271b7e.png)

Testing done:
-  Executed `tox -e docs` and verified that the generated html files had the paragraph rendered correctly.

Just like in the other pull request that i just submitted (#2940), I signed off my commits as it's recommended in the Contributors guidelines and I think I'm not forgetting something mentioned in there but please let me know if i am and I'll gladly correct it.

Thanks.