### PR TITLE
Use new testinfra package name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -52,7 +52,7 @@ repos:
         additional_dependencies:
           - packaging
           - rich
-          - subprocess-tee
+          - subprocess-tee>=0.1.4
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.6.0
     hooks:
@@ -60,5 +60,5 @@ repos:
         additional_dependencies:
           - ansible-base
           - rich
-          - subprocess-tee
+          - subprocess-tee>=0.1.4
           - testinfra

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,17 +108,17 @@ test =
     # related tools/plugins but w/o ansible, which can be installed separated.
     ansi2html
 
-    mock>=3.0.5
+    mock >= 3.0.5
     pexpect >= 4.6.0, < 5
-    pytest-cov>=2.7.1
-    pytest-helpers-namespace>=2019.1.8
-    pytest-html>=1.21.0
-    pytest-mock>=1.10.4
-    pytest-verbose-parametrize>=1.7.0
+    pytest-cov >= 2.7.1
+    pytest-helpers-namespace >= 2019.1.8
+    pytest-html >= 1.21.0
+    pytest-mock >= 1.10.4
     pytest-plus
-    pytest-xdist>=1.29.0
-    pytest>=5.4.0
-    testinfra >= 3.4.0
+    pytest-testinfra >= 6.0.0
+    pytest-verbose-parametrize >= 1.7.0
+    pytest-xdist >= 1.29.0
+    pytest >= 5.4.0
 lint =
     ansible-lint >= 4.2.0, < 5
     flake8 >= 3.6.0


### PR DESCRIPTION
As testinfra was transfered to pytest-dev, it also included a rename of the pypi package.