### PR TITLE
Check for successful `ansible --version` call

### DIFF
--- a/lib/molecule/config.py
+++ b/lib/molecule/config.py
@@ -461,10 +461,18 @@ def ansible_version(version: str = None) -> Version:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     universal_newlines=True,
+                    check=True,
                 )
                 .stdout.splitlines()[0]
                 .split()[1]
             )
+        except subprocess.CalledProcessError as exc:
+            LOG.fatal(
+                "Could not determine Ansible version. "
+                "Command `ansible --version` returned exit status %d.",
+                exc.returncode,
+            )
+            sysexit(RC_SETUP_ERROR)
         except FileNotFoundError:
             LOG.fatal(
                 "Unable to find ansible executable. Read https://molecule.readthedocs.io/en/latest/installation.html"


### PR DESCRIPTION
Check that the `ansible --version` command executes successfully or raise a subprocess.CalledProcessError. Otherwise , Ansible might print a message starting with "the full traceback was:" to stdout, eventually leading to the following cryptic exception:

```
packaging.version.InvalidVersion: Invalid version 'full'
```

With the check in place, the following exception is printed instead:

```
subprocess.CalledProcessError: Command ['ansible', '--version']' returned non-zero exit status 250.
```

#### PR Type

- Bugfix Pull Request