### PR TITLE
Prevent Ansible args from leaking to create and destroy

### DIFF
--- a/lib/molecule/provisioner/ansible_playbook.py
+++ b/lib/molecule/provisioner/ansible_playbook.py
@@ -67,14 +67,20 @@ class AnsiblePlaybook(object):
             if options.get("become"):
                 del options["become"]
 
-        ansible_args = list(self._config.provisioner.ansible_args) + list(
-            self._config.ansible_args
-        )
-
-        # if ansible_args:
-        #     if self._config.action not in ["create", "destroy"]:
-        #         # inserts ansible_args at index 1
-        #         self._ansible_command.cmd.extend(ansible_args)
+        # We do not pass user-specified Ansible arguments to the create and
+        # destroy invocations because playbooks involved in those two
+        # operations are not always provided by end users. And in those cases,
+        # custom Ansible arguments can break the creation and destruction
+        # processes.
+        #
+        # If users need to modify the creation of deletion, they can supply
+        # custom playbooks and specify them in the scenario configuration.
+        if self._config.action not in ["create", "destroy"]:
+            ansible_args = list(self._config.provisioner.ansible_args) + list(
+                self._config.ansible_args
+            )
+        else:
+            ansible_args = []
 
         self._ansible_command = util.BakedCommand(
             cmd=[

--- a/lib/molecule/test/unit/provisioner/test_ansible_playbook.py
+++ b/lib/molecule/test/unit/provisioner/test_ansible_playbook.py
@@ -118,8 +118,6 @@ def test_bake_does_not_have_ansible_args(_inventory_directory, _instance):
             _inventory_directory,
             "--skip-tags",
             "molecule-notest,notest",
-            "foo",
-            "bar",
             "playbook",
         ]
 


### PR DESCRIPTION
When we were removing the dependency on the sh Python package from the codebase, we inadvertently changed the behavior of the Ansible arguments that user supplies either on the command line on in the provisioner part of the scenario configuration (commit 1cefe5c21e8ef338a5769d65e4e0e3eb6b2256fc).

Changes in this commit restore the previous state when Ansible args were not passed to the create and destroy playbook executions.

Fixes #2963 

#### PR Type

- Bugfix Pull Request