### PR TITLE
Refactored text functions out of util module

### DIFF
--- a/lib/molecule/command/idempotence.py
+++ b/lib/molecule/command/idempotence.py
@@ -25,6 +25,7 @@ import click
 
 from molecule import logger, util
 from molecule.command import base
+from molecule.text import strip_ansi_escape
 
 LOG = logger.get_logger(__name__)
 
@@ -119,7 +120,7 @@ class Idempotence(base.Base):
         output = re.sub(r"\n\s*\n*", "\n", output)
 
         # Remove ansi escape sequences.
-        output = util.strip_ansi_escape(output)
+        output = strip_ansi_escape(output)
 
         # Split the output into a list and go through it.
         output_lines = output.split("\n")

--- a/lib/molecule/test/functional/conftest.py
+++ b/lib/molecule/test/functional/conftest.py
@@ -31,6 +31,7 @@ import pytest
 from molecule import logger, util
 from molecule.config import ansible_version
 from molecule.test.conftest import change_dir_to
+from molecule.text import strip_ansi_color
 from molecule.util import run_command
 
 LOG = logger.get_logger(__name__)
@@ -184,7 +185,7 @@ def list(x):
 def list_with_format_plain(x):
     cmd = ["molecule", "list", "--format", "plain"]
     result = util.run_command(cmd)
-    out = util.strip_ansi_color(result.stdout)
+    out = strip_ansi_color(result.stdout)
 
     for l in x.splitlines():
         assert l in out

--- a/lib/molecule/test/unit/test_scenarios.py
+++ b/lib/molecule/test/unit/test_scenarios.py
@@ -23,8 +23,9 @@ import copy
 
 import pytest
 
-from molecule import config, scenario, scenarios, util
+from molecule import config, scenario, scenarios
 from molecule.console import console
+from molecule.text import chomp, strip_ansi_escape
 
 
 @pytest.fixture
@@ -77,7 +78,7 @@ def test_all_filters_on_scenario_name_property(_instance):
 def test_print_matrix(capsys, _instance):
     with console.capture() as capture:
         _instance.print_matrix()
-    result = util.chomp(util.strip_ansi_escape(capture.get()))
+    result = chomp(strip_ansi_escape(capture.get()))
 
     matrix_out = u"""---
 default:

--- a/lib/molecule/test/unit/test_text.py
+++ b/lib/molecule/test/unit/test_text.py
@@ -1,0 +1,13 @@
+from molecule.text import strip_ansi_color, strip_ansi_escape
+
+
+def test_strip_ansi_escape():
+    string = "ls\r\n\x1b[00m\x1b[01;31mfoo\x1b[00m\r\n\x1b[01;31m"
+
+    assert "ls\r\nfoo\r\n" == strip_ansi_escape(string)
+
+
+def test_strip_ansi_color():
+    s = "foo\x1b[0m\x1b[0m\x1b[0m\n\x1b[0m\x1b[0m\x1b[0m\x1b[0m\x1b[0m"
+
+    assert "foo\n" == strip_ansi_color(s)

--- a/lib/molecule/test/unit/test_util.py
+++ b/lib/molecule/test/unit/test_util.py
@@ -29,6 +29,7 @@ import pytest
 from molecule import util
 from molecule.console import console
 from molecule.constants import MOLECULE_HEADER
+from molecule.text import strip_ansi_escape
 
 
 def test_print_debug():
@@ -37,7 +38,7 @@ def test_print_debug():
     with console.capture() as capture:
         util.print_debug("test_title", "test_data")
 
-    result = util.strip_ansi_escape(capture.get())
+    result = strip_ansi_escape(capture.get())
     assert result == expected
 
 
@@ -64,7 +65,7 @@ ANSIBLE_BAR=bar ANSIBLE_FOO=foo MOLECULE_BAR=bar MOLECULE_FOO=foo
 
     with console.capture() as capture:
         util.print_environment_vars(env)
-    result = util.strip_ansi_escape(capture.get())
+    result = strip_ansi_escape(capture.get())
     assert result == expected
 
 
@@ -227,18 +228,6 @@ def test_open_file(temp_dir):
 
 def test_instance_with_scenario_name():
     assert "foo-bar" == util.instance_with_scenario_name("foo", "bar")
-
-
-def test_strip_ansi_escape():
-    string = "ls\r\n\x1b[00m\x1b[01;31mfoo\x1b[00m\r\n\x1b[01;31m"
-
-    assert "ls\r\nfoo\r\n" == util.strip_ansi_escape(string)
-
-
-def test_strip_ansi_color():
-    s = "foo\x1b[0m\x1b[0m\x1b[0m\n\x1b[0m\x1b[0m\x1b[0m\x1b[0m\x1b[0m"
-
-    assert "foo\n" == util.strip_ansi_color(s)
 
 
 def test_verbose_flag():

--- a/lib/molecule/text.py
+++ b/lib/molecule/text.py
@@ -1,0 +1,30 @@
+"""Text utils."""
+import re
+
+
+def chomp(text: str) -> str:
+    """Remove any training spaces from string."""
+    return "\n".join([x.rstrip() for x in text.splitlines()])
+
+
+def strip_ansi_escape(data):
+    """Remove all ANSI escapes from string or bytes.
+
+    If bytes is passed instead of string, it will be converted to string
+    using UTF-8.
+    """
+    if isinstance(data, bytes):
+        data = data.decode("utf-8")
+
+    return re.sub(r"\x1b[^m]*m", "", data)
+
+
+def strip_ansi_color(data):
+    """Remove ANSI colors from string or bytes."""
+    if isinstance(data, bytes):
+        data = data.decode("utf-8")
+
+    # Taken from tabulate
+    invisible_codes = re.compile(r"\x1b\[\d*m")
+
+    return re.sub(invisible_codes, "", data)

--- a/lib/molecule/util.py
+++ b/lib/molecule/util.py
@@ -251,29 +251,6 @@ def instance_with_scenario_name(instance_name, scenario_name):
     return "{}-{}".format(instance_name, scenario_name)
 
 
-def strip_ansi_escape(data):
-    """Remove all ANSI escapes from string or bytes.
-
-    If bytes is passed instead of string, it will be converted to string
-    using UTF-8.
-    """
-    if isinstance(data, bytes):
-        data = data.decode("utf-8")
-
-    return re.sub(r"\x1b[^m]*m", "", data)
-
-
-def strip_ansi_color(data):
-    """Remove ANSI colors from string or bytes."""
-    if isinstance(data, bytes):
-        data = data.decode("utf-8")
-
-    # Taken from tabulate
-    invisible_codes = re.compile(r"\x1b\[\d*m")
-
-    return re.sub(invisible_codes, "", data)
-
-
 def verbose_flag(options):
     """Return computed verbosity flag."""
     verbose = "v"
@@ -440,8 +417,3 @@ def print_as_yaml(data: Any) -> None:
     """Render python object as yaml on console."""
     result = Syntax(safe_dump(data), "yaml")
     console.print(result)
-
-
-def chomp(text: str) -> str:
-    """Remove any training spaces from string."""
-    return "\n".join([x.rstrip() for x in text.splitlines()])


### PR DESCRIPTION
This move was needed for avoiding circular imports from upcoming refactoring of logging.
