### PR TITLE
Refreshed test dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -107,19 +107,19 @@ test =
     # Do not include ansible or any package that would drag ansible in here
     # We want to assure test extra provides tools to test molecule and its
     # related tools/plugins but w/o ansible, which can be installed separated.
-    ansi2html
+    ansi2html >= 1.6.0
 
-    mock >= 3.0.5
-    pexpect >= 4.6.0, < 5
-    pytest-cov >= 2.7.1
+    mock >= 4.0.2
+    pexpect >= 4.8.0, < 5
+    pytest-cov >= 2.10.1
     pytest-helpers-namespace >= 2019.1.8
-    pytest-html >= 1.21.0
-    pytest-mock >= 1.10.4
-    pytest-plus
-    pytest-testinfra >= 6.0.0
+    pytest-html >= 3.0.0
+    pytest-mock >= 3.3.1
+    pytest-plus >= 0.2
+    pytest-testinfra >= 6.1.0
     pytest-verbose-parametrize >= 1.7.0
-    pytest-xdist >= 1.29.0
-    pytest >= 5.4.0
+    pytest-xdist >= 2.1.0
+    pytest >= 6.1.2
 lint =
     ansible-lint >= 4.2.0, < 5
     flake8 >= 3.6.0


### PR DESCRIPTION
While we are forced to bump minimal ansi2html to 1.6.0 as this is the first version supporting py39, we take the opportunity to reduce the range of supported test dependencies to their current know versions.

This should lower the change of using outdated dependencies for testing.

