### PR TITLE
Refactor execute to use wrapper for logging

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -37,6 +37,18 @@ MOLECULE_GLOB = os.environ.get("MOLECULE_GLOB", "molecule/*/molecule.yml")
 MOLECULE_DEFAULT_SCENARIO_NAME = "default"
 
 
+def section_logger(func: Callable) -> Callable:
+    """Wrap effective execution of a method."""
+
+    def wrapper(*args, **kwargs):
+        args[0].print_info()
+        rt = func(*args, **kwargs)
+        # section close code goes here
+        return rt
+
+    return wrapper
+
+
 class Base(object, metaclass=abc.ABCMeta):
     """An abstract base class used to define the command interface."""
 
@@ -49,6 +61,11 @@ class Base(object, metaclass=abc.ABCMeta):
         """
         self._config = c
         self._setup()
+
+    def __init_subclass__(cls) -> None:
+        """Decorate execute from all subclasses."""
+        super().__init_subclass__()
+        setattr(cls, "execute", section_logger(cls.execute))
 
     @abc.abstractmethod
     def execute(self):  # pragma: no cover

--- a/src/molecule/command/check.py
+++ b/src/molecule/command/check.py
@@ -79,7 +79,6 @@ class Check(base.Base):
 
         :return: None
         """
-        self.print_info()
         self._config.provisioner.check()
 
 

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -73,8 +73,6 @@ class Cleanup(base.Base):
 
         :return: None
         """
-        self.print_info()
-
         if not self._config.provisioner.playbooks.cleanup:
             msg = "Skipping, cleanup playbook not configured."
             LOG.warning(msg)

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -79,7 +79,6 @@ class Converge(base.Base):
 
         :return: None
         """
-        self.print_info()
         self._config.provisioner.converge()
         self._config.state.change_state("converged", True)
 

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -78,7 +78,6 @@ class Create(base.Base):
 
         :return: None
         """
-        self.print_info()
         self._config.state.change_state("driver", self._config.driver.name)
 
         if self._config.driver.delegated and not self._config.driver.managed:

--- a/src/molecule/command/dependency.py
+++ b/src/molecule/command/dependency.py
@@ -70,7 +70,6 @@ class Dependency(base.Base):
 
         :return: None
         """
-        self.print_info()
         self._config.dependency.execute()
 
 

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -93,8 +93,6 @@ class Destroy(base.Base):
 
         :return: None
         """
-        self.print_info()
-
         if self._config.command_args.get("destroy") == "never":
             msg = "Skipping, '--destroy=never' requested."
             LOG.warning(msg)

--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -74,7 +74,6 @@ class Idempotence(base.Base):
 
         :return: None
         """
-        self.print_info()
         if not self._config.state.converged:
             msg = "Instances not converged.  Please converge instances first."
             util.sysexit_with_message(msg)

--- a/src/molecule/command/lint.py
+++ b/src/molecule/command/lint.py
@@ -80,8 +80,6 @@ class Lint(base.Base):
 
         :return: None
         """
-        self.print_info()
-
         # v3 migration code:
         cmd = self._config.lint
         if not cmd:

--- a/src/molecule/command/prepare.py
+++ b/src/molecule/command/prepare.py
@@ -89,8 +89,6 @@ class Prepare(base.Base):
 
         :return: None
         """
-        self.print_info()
-
         if self._config.state.prepared and not self._config.command_args.get("force"):
             msg = "Skipping, instances already prepared."
             LOG.warning(msg)

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -72,7 +72,6 @@ class SideEffect(base.Base):
 
         :return: None
         """
-        self.print_info()
         if not self._config.provisioner.playbooks.side_effect:
             msg = "Skipping, side effect playbook not configured."
             LOG.warning(msg)

--- a/src/molecule/command/syntax.py
+++ b/src/molecule/command/syntax.py
@@ -69,7 +69,6 @@ class Syntax(base.Base):
 
         :return: None
         """
-        self.print_info()
         self._config.provisioner.syntax()
 
 

--- a/src/molecule/command/verify.py
+++ b/src/molecule/command/verify.py
@@ -70,7 +70,6 @@ class Verify(base.Base):
 
         :return: None
         """
-        self.print_info()
         self._config.verifier.execute()
 
 


### PR DESCRIPTION
Avoid each implementation of Command to call logging and use a wrapped to log executions of each subclass.

