### PR TITLE
Removed custom logger

### DIFF
--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -78,12 +78,12 @@ class Idempotence(base.Base):
             msg = "Instances not converged.  Please converge instances first."
             util.sysexit_with_message(msg)
 
-        output = self._config.provisioner.converge(out=None, err=None)
+        output = self._config.provisioner.converge()
 
         idempotent = self._is_idempotent(output)
         if idempotent:
             msg = "Idempotence completed successfully."
-            LOG.success(msg)
+            LOG.info(msg)
         else:
             msg = (
                 "Idempotence test failed because of the following tasks:\n" u"{}"

--- a/src/molecule/command/init/role.py
+++ b/src/molecule/command/init/role.py
@@ -89,7 +89,7 @@ class Role(base.Base):
 
         role_directory = os.path.join(role_directory, role_name)
         msg = "Initialized role in {} successfully.".format(role_directory)
-        LOG.success(msg)
+        LOG.info(msg)
 
 
 @command_base.click_command_ex()

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -112,7 +112,7 @@ class Scenario(base.Base):
 
         role_directory = os.path.join(role_directory, role_name)
         msg = "Initialized scenario in {} successfully.".format(scenario_directory)
-        LOG.success(msg)
+        LOG.info(msg)
 
 
 def _role_exists(ctx, param, value):  # pragma: no cover

--- a/src/molecule/dependency/ansible_galaxy/base.py
+++ b/src/molecule/dependency/ansible_galaxy/base.py
@@ -107,8 +107,6 @@ class AnsibleGalaxyBase(base.Base):
         self._sh_command = util.BakedCommand(
             cmd=[self.command, *self.COMMANDS, *util.dict2args(options), *verbose_flag],
             env=self.env,
-            stdout=LOG.out,
-            stderr=LOG.error,
         )
 
     def execute(self):

--- a/src/molecule/dependency/base.py
+++ b/src/molecule/dependency/base.py
@@ -55,7 +55,7 @@ class Base(object):
             # print(555, self._sh_command)
             util.run_command(self._sh_command, debug=self._config.debug)
             msg = "Dependency completed successfully."
-            LOG.success(msg)
+            LOG.info(msg)
             return
         except Exception:
             pass
@@ -72,7 +72,7 @@ class Base(object):
             try:
                 util.run_command(self._sh_command, debug=self._config.debug)
                 msg = "Dependency completed successfully."
-                LOG.success(msg)
+                LOG.info(msg)
                 return
             except Exception as _exception:
                 exception = _exception

--- a/src/molecule/logger.py
+++ b/src/molecule/logger.py
@@ -26,8 +26,7 @@ from functools import lru_cache
 from enrich.console import Console
 from enrich.logging import RichHandler
 
-from molecule.console import console, should_do_markup, theme
-from molecule.text import chomp
+from molecule.console import should_do_markup, theme
 
 SUCCESS = 100
 OUT = 101
@@ -43,29 +42,6 @@ class LogFilter(logging.Filter):
     def filter(self, logRecord):  # pragma: no cover
         # https://docs.python.org/3/library/logging.html#logrecord-attributes
         return logRecord.levelno <= self.__level
-
-
-class CustomLogger(logging.getLoggerClass()):  # type: ignore  # see https://sam.hooke.me/note/2020/03/mypy-and-verbose-logging/
-    """
-    A custom logging class which adds additional methods to the logger.
-
-    These methods serve as syntactic sugar for formatting log messages.
-    """
-
-    def __init__(self, name, level=logging.NOTSET):
-        """Construct CustomLogger."""
-        super(CustomLogger, self).__init__(name, level=level)
-        logging.addLevelName(SUCCESS, "SUCCESS")
-        logging.addLevelName(OUT, "OUT")
-
-    def success(self, msg, *args, **kwargs):
-        if self.isEnabledFor(SUCCESS):
-            self._log(SUCCESS, msg, args, **kwargs)
-
-    def out(self, msg, *args, **kwargs):
-        msg = chomp(msg)
-        if self.isEnabledFor(OUT):
-            console.print(msg, args, **kwargs)
 
 
 class TrailingNewlineFormatter(logging.Formatter):
@@ -86,8 +62,6 @@ def get_logger(name=None) -> logging.Logger:
                  name, ``__name__``.
     :return: logger object
     """
-    logging.setLoggerClass(CustomLogger)
-
     logger = logging.getLogger(name)  # type: logging.Logger
     logger.setLevel(logging.DEBUG)
 

--- a/src/molecule/provisioner/ansible_playbook.py
+++ b/src/molecule/provisioner/ansible_playbook.py
@@ -18,7 +18,6 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 """Ansible-Playbook Provisioner Module."""
-
 from molecule import logger, util
 
 LOG = logger.get_logger(__name__)
@@ -27,24 +26,18 @@ LOG = logger.get_logger(__name__)
 class AnsiblePlaybook(object):
     """Privisioner Playbook."""
 
-    def __init__(self, playbook, config, out=LOG.out, err=LOG.error):
+    def __init__(self, playbook, config):
         """
         Set up the requirements to execute ``ansible-playbook`` and returns \
         None.
 
         :param playbook: A string containing the path to the playbook.
         :param config: An instance of a Molecule config.
-        :param out: An optional function to process STDOUT for underlying
-         :func:``sh`` call.
-        :param err: An optional function to process STDERR for underlying
-         :func:``sh`` call.
         :returns: None
         """
         self._ansible_command = None
         self._playbook = playbook
         self._config = config
-        self._out = out
-        self._err = err
         self._cli = {}
         self._env = self._config.provisioner.env
 
@@ -92,8 +85,6 @@ class AnsiblePlaybook(object):
             ],
             cwd=self._config.scenario.directory,
             env=self._env,
-            stdout=self._out,
-            stderr=self._err,
         )
 
     def execute(self):

--- a/src/molecule/test/functional/conftest.py
+++ b/src/molecule/test/functional/conftest.py
@@ -73,7 +73,7 @@ def with_scenario(request, scenario_to_test, driver_name, scenario_name, skip_te
         yield
         if scenario_name:
             msg = "CLEANUP: Destroying instances for all scenario(s)"
-            LOG.out(msg)
+            LOG.info(msg)
             cmd = ["molecule", "destroy", "--driver-name", driver_name, "--all"]
             assert run_command(cmd).returncode == 0
 

--- a/src/molecule/test/unit/command/init/test_role.py
+++ b/src/molecule/test/unit/command/init/test_role.py
@@ -43,18 +43,18 @@ def _instance(_command_args):
     return role.Role(_command_args)
 
 
-def test_execute(temp_dir, _instance, patched_logger_info, patched_logger_success):
+def test_execute(temp_dir, _instance, patched_logger_info):
     _instance.execute()
 
     msg = "Initializing new role test-role..."
-    patched_logger_info.assert_called_once_with(msg)
+    patched_logger_info.assert_any_call(msg)
 
     assert os.path.isdir("./test-role")
     assert os.path.isdir("./test-role/molecule/default")
 
     role_directory = os.path.join(temp_dir.strpath, "test-role")
     msg = "Initialized role in {} successfully.".format(role_directory)
-    patched_logger_success.assert_called_once_with(msg)
+    patched_logger_info.assert_any_call(msg)
 
 
 def test_execute_role_exists(temp_dir, _instance, patched_logger_critical):

--- a/src/molecule/test/unit/command/init/test_scenario.py
+++ b/src/molecule/test/unit/command/init/test_scenario.py
@@ -49,17 +49,17 @@ def invalid_template_dir(resources_folder_path):
     return invalid_role_template_path
 
 
-def test_execute(temp_dir, _instance, patched_logger_info, patched_logger_success):
+def test_execute(temp_dir, _instance, patched_logger_info):
     _instance.execute()
 
     msg = "Initializing new scenario test-scenario..."
-    patched_logger_info.assert_called_once_with(msg)
+    patched_logger_info.assert_any_call(msg)
 
     assert os.path.isdir("./molecule/test-scenario")
 
     scenario_directory = os.path.join(temp_dir.strpath, "molecule", "test-scenario")
     msg = "Initialized scenario in {} successfully.".format(scenario_directory)
-    patched_logger_success.assert_called_once_with(msg)
+    patched_logger_info.assert_any_call(msg)
 
 
 def test_execute_scenario_exists(temp_dir, _instance, patched_logger_critical):

--- a/src/molecule/test/unit/command/test_idempotence.py
+++ b/src/molecule/test/unit/command/test_idempotence.py
@@ -17,7 +17,6 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
-
 import pytest
 
 from molecule.command import idempotence
@@ -43,22 +42,21 @@ def test_execute(
     patched_logger_info,
     patched_ansible_converge,
     _patched_is_idempotent,
-    patched_logger_success,
     _instance,
 ):
     _instance.execute()
 
-    assert len(patched_logger_info.mock_calls) == 1
+    assert len(patched_logger_info.mock_calls) == 2
     name, args, kwargs = patched_logger_info.mock_calls[0]
     assert "default" in args
     assert "idempotence" in args
 
-    patched_ansible_converge.assert_called_once_with(out=None, err=None)
+    patched_ansible_converge.assert_called_once_with()
 
     _patched_is_idempotent.assert_called_once_with("patched-ansible-converge-stdout")
 
     msg = "Idempotence completed successfully."
-    patched_logger_success.assert_called_once_with(msg)
+    patched_logger_info.assert_any_call(msg)
 
 
 def test_execute_raises_when_not_converged(

--- a/src/molecule/test/unit/conftest.py
+++ b/src/molecule/test/unit/conftest.py
@@ -168,11 +168,6 @@ def patched_logger_debug(mocker):
 
 
 @pytest.fixture
-def patched_logger_out(mocker):
-    return mocker.patch("molecule.logger.CustomLogger.out")
-
-
-@pytest.fixture
 def patched_logger_warning(mocker):
     return mocker.patch("logging.Logger.warning")
 
@@ -185,11 +180,6 @@ def patched_logger_error(mocker):
 @pytest.fixture
 def patched_logger_critical(mocker):
     return mocker.patch("logging.Logger.critical")
-
-
-@pytest.fixture
-def patched_logger_success(mocker):
-    return mocker.patch("molecule.logger.CustomLogger.success")
 
 
 @pytest.fixture

--- a/src/molecule/test/unit/dependency/ansible_galaxy/test_collections.py
+++ b/src/molecule/test/unit/dependency/ansible_galaxy/test_collections.py
@@ -149,7 +149,7 @@ def test_collections_bake(_instance, role_file, roles_path):
 def test_execute(
     patched_run_command,
     _patched_ansible_galaxy_has_requirements_file,
-    patched_logger_success,
+    patched_logger_info,
     _instance,
 ):
     _instance._sh_command = "patched-command"
@@ -163,7 +163,7 @@ def test_execute(
     patched_run_command.assert_called_once_with("patched-command", debug=False)
 
     msg = "Dependency completed successfully."
-    patched_logger_success.assert_called_once_with(msg)
+    patched_logger_info.assert_called_once_with(msg)
 
 
 def test_execute_does_not_execute_when_disabled(

--- a/src/molecule/test/unit/dependency/ansible_galaxy/test_roles.py
+++ b/src/molecule/test/unit/dependency/ansible_galaxy/test_roles.py
@@ -145,7 +145,7 @@ def test_galaxy_bake(_instance, role_file, roles_path):
 def test_execute(
     patched_run_command,
     _patched_ansible_galaxy_has_requirements_file,
-    patched_logger_success,
+    patched_logger_info,
     _instance,
 ):
     _instance._sh_command = "patched-command"
@@ -159,7 +159,7 @@ def test_execute(
     patched_run_command.assert_called_once_with("patched-command", debug=False)
 
     msg = "Dependency completed successfully."
-    patched_logger_success.assert_called_once_with(msg)
+    patched_logger_info.assert_called_once_with(msg)
 
 
 def test_execute_does_not_execute_when_disabled(

--- a/src/molecule/test/unit/dependency/test_shell.py
+++ b/src/molecule/test/unit/dependency/test_shell.py
@@ -90,14 +90,14 @@ def test_env_property(_instance):
     assert "bar" == _instance.env["FOO"]
 
 
-def test_execute(patched_run_command, patched_logger_success, _instance):
+def test_execute(patched_run_command, patched_logger_info, _instance):
     _instance._sh_command = "patched-command"
     _instance.execute()
 
     patched_run_command.assert_called_once_with("patched-command", debug=False)
 
     msg = "Dependency completed successfully."
-    patched_logger_success.assert_called_once_with(msg)
+    patched_logger_info.assert_called_once_with(msg)
 
 
 def test_execute_does_not_execute_when_disabled(

--- a/src/molecule/test/unit/test_config.py
+++ b/src/molecule/test/unit/test_config.py
@@ -292,9 +292,7 @@ def test_preflight_exists_when_validation_fails(
     patched_logger_critical.assert_called_once_with(msg)
 
 
-def test_validate(
-    mocker, config_instance, patched_logger_debug, patched_logger_success
-):
+def test_validate(mocker, config_instance, patched_logger_debug):
     m = mocker.patch("molecule.model.schema_v3.validate")
     m.return_value = None
 

--- a/src/molecule/test/unit/verifier/test_ansible.py
+++ b/src/molecule/test/unit/verifier/test_ansible.py
@@ -76,18 +76,16 @@ def test_options_property_handles_cli_args(_instance):
     assert x == _instance.options
 
 
-def test_execute(
-    patched_logger_info, _patched_ansible_verify, patched_logger_success, _instance
-):
+def test_execute(patched_logger_info, _patched_ansible_verify, _instance):
     _instance.execute()
 
     _patched_ansible_verify.assert_called_once_with()
 
     msg = "Running Ansible Verifier"
-    patched_logger_info.assert_called_once_with(msg)
+    patched_logger_info.assert_any_call(msg)
 
     msg = "Verifier completed successfully."
-    patched_logger_success.assert_called_once_with(msg)
+    patched_logger_info.assert_any_call(msg)
 
 
 def test_execute_does_not_execute(

--- a/src/molecule/test/unit/verifier/test_testinfra.py
+++ b/src/molecule/test/unit/verifier/test_testinfra.py
@@ -21,6 +21,7 @@
 import os
 
 import pytest
+from mock import call
 
 from molecule import config, util
 from molecule.verifier import testinfra
@@ -228,7 +229,6 @@ def test_execute(
     patched_logger_info,
     patched_run_command,
     _patched_testinfra_get_tests,
-    patched_logger_success,
     _instance,
 ):
     _instance._testinfra_command = "patched-command"
@@ -237,10 +237,9 @@ def test_execute(
     patched_run_command.assert_called_once_with("patched-command", debug=False)
 
     msg = "Executing Testinfra tests found in {}/...".format(_instance.directory)
-    patched_logger_info.assert_called_once_with(msg)
-
-    msg = "Verifier completed successfully."
-    patched_logger_success.assert_called_once_with(msg)
+    msg2 = "Verifier completed successfully."
+    calls = [call(msg), call(msg2)]
+    patched_logger_info.assert_has_calls(calls)
 
 
 def test_execute_does_not_execute(

--- a/src/molecule/verifier/ansible.py
+++ b/src/molecule/verifier/ansible.py
@@ -82,7 +82,7 @@ class Ansible(Verifier):
         self._config.provisioner.verify()
 
         msg = "Verifier completed successfully."
-        log.success(msg)
+        log.info(msg)
 
     def schema(self):
         return {

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -161,8 +161,6 @@ class Testinfra(Verifier):
             cmd=["pytest", *util.dict2args(options), *self._tests, *args],
             cwd=self._config.scenario.directory,
             env=self.env,
-            stdout=LOG.out,
-            stderr=LOG.error,
         )
         # print(self._testinfra_command.cmd)
 
@@ -186,7 +184,7 @@ class Testinfra(Verifier):
         result = util.run_command(self._testinfra_command, debug=self._config.debug)
         if result.returncode == 0:
             msg = "Verifier completed successfully."
-            LOG.success(msg)
+            LOG.info(msg)
         else:
             util.sysexit(result.returncode)
 


### PR DESCRIPTION
Molecule no longer uses a custom logger class and we make use of the standard python logger class.

This change replaces `logger.success()` and `logger.out()` with `logger.info()` calls.

