### PR TITLE
Assure we install dataclasses on py36

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ install_requires =
     click-completion >= 0.5.1
     click-help-colors >= 0.6
     cookiecutter >= 1.6.0, != 1.7.1
+    dataclasses; python_version<"3.7"
     enrich >= 1.2.1
     Jinja2 >= 2.10.1
     packaging


### PR DESCRIPTION
dataclasses ships only with py37 or newer so we need to install the backport for older versions.