### PR TITLE
Enable multiple section wrappers

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -38,24 +38,6 @@ MOLECULE_GLOB = os.environ.get("MOLECULE_GLOB", "molecule/*/molecule.yml")
 MOLECULE_DEFAULT_SCENARIO_NAME = "default"
 
 
-def section_logger(func: Callable) -> Callable:
-    """Wrap effective execution of a method."""
-
-    def wrapper(*args, **kwargs):
-        self = args[0]
-        LOG.info(
-            "[info]Running [scenario]%s[/] > [action]%s[/][/]",
-            self._config.scenario.name,
-            text.underscore(self.__class__.__name__),
-            extra={"markup": True},
-        )
-        rt = func(*args, **kwargs)
-        # section close code goes here
-        return rt
-
-    return wrapper
-
-
 class Base(object, metaclass=abc.ABCMeta):
     """An abstract base class used to define the command interface."""
 
@@ -72,7 +54,8 @@ class Base(object, metaclass=abc.ABCMeta):
     def __init_subclass__(cls) -> None:
         """Decorate execute from all subclasses."""
         super().__init_subclass__()
-        setattr(cls, "execute", section_logger(cls.execute))
+        for wrapper in logger.get_section_loggers():
+            setattr(cls, "execute", wrapper(cls.execute))
 
     @abc.abstractmethod
     def execute(self):  # pragma: no cover

--- a/src/molecule/logger.py
+++ b/src/molecule/logger.py
@@ -22,11 +22,13 @@
 import logging
 import sys
 from functools import lru_cache
+from typing import Callable, Iterable
 
 from enrich.console import Console
 from enrich.logging import RichHandler
 
 from molecule.console import should_do_markup, theme
+from molecule.text import underscore
 
 SUCCESS = 100
 OUT = 101
@@ -72,6 +74,29 @@ def get_logger(name=None) -> logging.Logger:
     logger.propagate = False
 
     return logger
+
+
+def section_logger(func: Callable) -> Callable:
+    """Wrap effective execution of a method."""
+
+    def wrapper(*args, **kwargs):
+        self = args[0]
+        get_logger().info(
+            "[info]Running [scenario]%s[/] > [action]%s[/][/]",
+            self._config.scenario.name,
+            underscore(self.__class__.__name__),
+            extra={"markup": True},
+        )
+        rt = func(*args, **kwargs)
+        # section close code goes here
+        return rt
+
+    return wrapper
+
+
+def get_section_loggers() -> Iterable[Callable]:
+    """Return a list of section wrappers to be added."""
+    return [section_logger]
 
 
 LOGGING_CONSOLE = Console(


### PR DESCRIPTION
Moves the recently added section_logger to the logger module and enable us to use multiple wrappers. This should make
implementation of https://github.com/ansible-community/molecule/pull/2976 much easier.