### PR TITLE
Remove mock as a dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -110,7 +110,6 @@ test =
     # related tools/plugins but w/o ansible, which can be installed separated.
     ansi2html >= 1.6.0
 
-    mock >= 4.0.2
     pexpect >= 4.8.0, < 5
     pytest-cov >= 2.10.1
     pytest-helpers-namespace >= 2019.1.8

--- a/src/molecule/test/unit/verifier/test_testinfra.py
+++ b/src/molecule/test/unit/verifier/test_testinfra.py
@@ -19,9 +19,9 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import os
+from unittest.mock import call
 
 import pytest
-from unittest.mock import call
 
 from molecule import config, util
 from molecule.verifier import testinfra

--- a/src/molecule/test/unit/verifier/test_testinfra.py
+++ b/src/molecule/test/unit/verifier/test_testinfra.py
@@ -21,7 +21,7 @@
 import os
 
 import pytest
-from mock import call
+from unittest.mock import call
 
 from molecule import config, util
 from molecule.verifier import testinfra


### PR DESCRIPTION
unittest.mock is built into python3 so mock should not be needed.
This package is only for python3

`pytest-mock` (mocker fixture)
Also will use unittest.mock:
https://github.com/pytest-dev/pytest-mock/blob/9e1464bb87d551b1a242104b68bad8d8a1429316/src/pytest_mock/plugin.py#L22

#### PR Type
- Feature Pull Request
