### PR TITLE
docs/getting-started.rst: Add missing argument to init role

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -32,7 +32,7 @@ To generate a new role with Molecule, simply run:
 
 .. code-block:: bash
 
-    $ molecule init role my-new-role
+    $ molecule init role my-new-role --driver-name docker
 
 You should then see a ``my-new-role`` folder in your current directory.
 


### PR DESCRIPTION
The default driver is 'delegated' nowadays and this document is
about using the 'docker' driver, so "--driver-name docker" has to
be appended to the "molecule init role" command line.

Ref: https://github.com/ansible-community/molecule/discussions/2916
Signed-off-by: Arnaud Patard <apatard@hupstream.com>


#### PR Type

- Docs Pull Request
