### PR TITLE
Allow to set login_cmd_template for delegate driver

### DIFF
--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -148,6 +148,9 @@ class Delegated(Driver):
 
     @property
     def login_cmd_template(self):
+        if "login_cmd_template" in self.options:
+            return self.options["login_cmd_template"]
+
         if self.managed:
             connection_options = " ".join(self.ssh_connection_options)
 
@@ -158,7 +161,6 @@ class Delegated(Driver):
                 "-i {{identity_file}} "
                 "{}"
             ).format(connection_options)
-        return self.options["login_cmd_template"]
 
     @property
     def default_safe_files(self):


### PR DESCRIPTION
…managed case

The current code only allows to configure the login command
if molecule is configured to use non managed instance but it may
be helpful to be able to set it even if the instance is managed.

For instance, if the instance (eg a chroot or a container) can be
created with the create.yml playbook, which means that this instance is
reachable with something else than ssh.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>

Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
