### PR TITLE
src/molecule/console.py: Don't always set output wrapping

### DIFF
--- a/src/molecule/console.py
+++ b/src/molecule/console.py
@@ -72,7 +72,11 @@ def should_do_markup() -> bool:
 
 
 console = Console(
-    force_terminal=should_do_markup(), theme=theme, record=True, redirect=True
+    force_terminal=should_do_markup(),
+    theme=theme,
+    record=True,
+    redirect=True,
+    soft_wrap=should_do_markup(),
 )
 # Define ANSIBLE_FORCE_COLOR if markup is enabled and another value is not
 # already given. This assures that Ansible subprocesses are still colored,


### PR DESCRIPTION
The output soft wrapping with python enrich is enabled for all
terminals. This means that lines are wrapped to 80 when molecule
is run from tox or when a module ends importing this console module.
In the later case, this will wrap its output to 80 columns and
possibly break it, since the output won't be valid JSON as found in
https://github.com/ansible-community/molecule-vagrant/issues/84.

As a possible solution, enable the soft wrapping on the same condition
as for the force_terminal terminal.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>

#### PR Type

- Bugfix Pull Request
