### PR TITLE
Assure provisioner logging is enabled by default

### DIFF
--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -359,6 +359,7 @@ class Config(object, metaclass=NewInitCaller):
                     "side_effect": "side_effect.yml",
                     "verify": "verify.yml",
                 },
+                "log": True,
             },
             "scenario": {
                 "name": scenario_name,


### PR DESCRIPTION
This fixes confuses where creating instances fail without details.
This change will not affect users that already mentioned their
preferences in config or as environment variable.

Related: https://github.com/ansible-community/molecule-podman/issues/22