### PR TITLE
Automatically install current collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,25 @@
+# Molecule is not really a collection but this file is use for testing molecule
+# ability to detect and install a local collection.
+namespace: _test
+name: molecule
+version: 0.0.1
+readme: README.rst
+authors:
+  - Ansible
+build_ignore:
+  - "**/*.egg-info"
+  - "**/.mypy_cache"
+  - .cache
+  - .coverage
+  - .eggs
+  - .github
+  - .gitignore
+  - .pytest_cache
+  - .vscode
+  - asset
+  - build
+  - coverage.xml
+  - dist
+  - docs/docstree/html
+  - pip-wheel-metadata
+  - tox.ini

--- a/src/molecule/dependency/ansible_galaxy/__init__.py
+++ b/src/molecule/dependency/ansible_galaxy/__init__.py
@@ -72,6 +72,7 @@ class AnsibleGalaxy(Base):
         self.invocations = [Roles(config), Collections(config)]
 
     def execute(self):
+        super().execute()
         for invoker in self.invocations:
             invoker.execute()
 
@@ -85,7 +86,7 @@ class AnsibleGalaxy(Base):
     def default_env(self):
         e = {}
         for invoker in self.invocations:
-            e = util.merge(e, invoker.default_env)
+            e = util.merge_dicts(e, invoker.default_env)
         return e
 
     @property

--- a/src/molecule/dependency/shell.py
+++ b/src/molecule/dependency/shell.py
@@ -89,6 +89,7 @@ class Shell(base.Base):
         self._sh_command = BakedCommand(cmd=self.command, env=self.env)
 
     def execute(self):
+        super().execute()
         if not self.enabled:
             msg = "Skipping, dependency is disabled."
             LOG.warning(msg)


### PR DESCRIPTION
If run inside a collection repository dependency step will first
build and install the current collection. This avoids failure to
run test scenarios unless user already installed the collection.

Fixes: #2997
