### PR TITLE
Acknowledge click 8.0 incompatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ setup_requires =
 # These are required in actual runtime:
 install_requires =
     cerberus >= 1.3.1
-    click >= 7.0
+    click >= 7.0, < 8.0  # https://github.com/click-contrib/click-help-colors/issues/12
     click-completion >= 0.5.1
     click-help-colors >= 0.6
     cookiecutter >= 1.6.0, != 1.7.1


### PR DESCRIPTION
Upcoming changes in click break click-help-colors plugin so we need to prevent breaking at runtime until upstream issues are sorted.

This bug was found by our "eco" job which installs pre-releases, a first proof that preventive measure work.

Related: https://github.com/click-contrib/click-help-colors/issues/12
Related: https://github.com/pallets/click/issues/1721
