### PR TITLE
Extend run_command implementation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ install_requires =
     pluggy >= 0.7.1, < 1.0
     PyYAML >= 5.1, < 6
     rich >= 6.0
-    subprocess-tee >= 0.1.5
+    subprocess-tee >= 0.1.6
     setuptools >= 42 # for pkg_resources
     yamllint >= 1.15.0, < 2
     # selinux python module is needed as least by ansible-docker/podman modules


### PR DESCRIPTION
- adds missing cwd argument
- adds missing check argument which works similar to one in subprocess  with the only difference being that it does perform a clean exist, without leaving a confusing stacktrace.
