### PR TITLE
Refactored use of console for logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,14 +51,14 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - packaging
-          - enrich>=1.2
-          - subprocess-tee>=0.1.5
+          - enrich>=1.2.5
+          - subprocess-tee>=0.2.0
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.6.0
     hooks:
       - id: pylint
         additional_dependencies:
           - ansible-base
-          - enrich>=1.2
-          - subprocess-tee>=0.1.5
+          - enrich>=1.2.5
+          - subprocess-tee>=0.2.0
           - testinfra

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,14 +72,14 @@ install_requires =
     click-help-colors >= 0.6
     cookiecutter >= 1.6.0, != 1.7.1
     dataclasses; python_version<"3.7"
-    enrich >= 1.2.4, < 1.2.5
+    enrich >= 1.2.5
     Jinja2 >= 2.10.1
     packaging
     paramiko >= 2.5.0, < 3
     pluggy >= 0.7.1, < 1.0
     PyYAML >= 5.1, < 6
-    rich >= 6.0, < 9.5
-    subprocess-tee >= 0.1.6, < 0.2.0
+    rich >= 9.5.1
+    subprocess-tee >= 0.2.0
     setuptools >= 42 # for pkg_resources
     yamllint >= 1.15.0, < 2
     # selinux python module is needed as least by ansible-docker/podman modules

--- a/src/molecule/logger.py
+++ b/src/molecule/logger.py
@@ -21,15 +21,13 @@
 
 import logging
 import os
-import sys
 import time
 from functools import lru_cache, wraps
 from typing import Callable, Iterable
 
-from enrich.console import Console
 from enrich.logging import RichHandler
 
-from molecule.console import console, should_do_markup, theme
+from molecule.console import console
 from molecule.text import underscore
 
 LOG = logging.getLogger(__name__)
@@ -48,7 +46,7 @@ def configure() -> None:
     """
     logger = logging.getLogger("molecule")
     handler = RichHandler(
-        console=LOGGING_CONSOLE, show_time=False, show_path=False, markup=True
+        console=console, show_time=False, show_path=False, markup=True
     )  # type: ignore
     logger.addHandler(handler)
     logger.propagate = False
@@ -205,8 +203,3 @@ def get_section_loggers() -> Iterable[Callable]:
         return [travis_ci_folds] + default_section_loggers
     # CI is set but no extra section_loggers apply.
     return default_section_loggers
-
-
-LOGGING_CONSOLE = Console(
-    file=sys.stderr, force_terminal=should_do_markup(), theme=theme
-)

--- a/src/molecule/shell.py
+++ b/src/molecule/shell.py
@@ -18,6 +18,7 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 """Molecule Shell Module."""
+import atexit
 import os
 import sys
 
@@ -31,7 +32,7 @@ from molecule.api import drivers
 from molecule.command.base import click_group_ex
 from molecule.config import MOLECULE_DEBUG, MOLECULE_VERBOSITY, ansible_version
 from molecule.console import console
-from molecule.util import lookup_config_file
+from molecule.util import do_report, lookup_config_file
 
 click_completion.init()
 
@@ -125,6 +126,9 @@ def main(ctx, debug, verbose, base_config, env_file):  # pragma: no cover
     logger.set_log_level(verbose, debug)
     if verbose:
         os.environ["ANSIBLE_VERBOSITY"] = str(verbose)
+
+    if "MOLECULE_REPORT" in os.environ:
+        atexit.register(do_report)
 
 
 main.add_command(command.cleanup.cleanup)

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -81,14 +81,17 @@ def print_environment_vars(env: Optional[Dict[str, str]]) -> None:
         print()
 
 
+def do_report() -> None:
+    """Dump html report atexit."""
+    report_file = os.environ["MOLECULE_REPORT"]
+    LOG.info("Writing %s report.", report_file)
+    with open(report_file, "w") as f:
+        f.write(console.export_html())
+        f.close()
+
+
 def sysexit(code: int = 1) -> NoReturn:
     """Perform a system exit with given code, default 1."""
-    if "MOLECULE_REPORT" in os.environ:
-        report_file = os.environ["MOLECULE_REPORT"]
-        LOG.info("Writing %s report.", report_file)
-        with open(report_file, "w") as f:
-            f.write(console.export_html())
-
     sys.exit(code)
 
 


### PR DESCRIPTION
- fix bug that produced incomplete reports due to the report generation
  being called multiple times.
- assure that logging use the same console object, so we include the
  logged messaged inside the report
- current limitation of console prevents us from using stderr for
  out own logging; we plan to restore use of stderr for logging in
  a followup.

Fixes: #3010