### PR TITLE
Allow os_walk to follow symlinks

### DIFF
--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -160,9 +160,9 @@ def run_command(
     return result
 
 
-def os_walk(directory, pattern, excludes=[]):
+def os_walk(directory, pattern, excludes=[], followlinks=False):
     """Navigate recursively and retried files based on pattern."""
-    for root, dirs, files in os.walk(directory, topdown=True):
+    for root, dirs, files in os.walk(directory, topdown=True, followlinks=followlinks):
         dirs[:] = [d for d in dirs if d not in excludes]
         for basename in files:
             if fnmatch.fnmatch(basename, pattern):

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -196,7 +196,12 @@ class Testinfra(Verifier):
         :return: list
         """
         return sorted(
-            [filename for filename in util.os_walk(self.directory, "test_*.py")]
+            [
+                filename
+                for filename in util.os_walk(
+                    self.directory, "test_*.py", followlinks=True
+                )
+            ]
         )
 
     def schema(self):


### PR DESCRIPTION
Allows the testinfra verifier to follow symlinks in the tests
directory.

This fixes a bug described here:
https://github.com/ansible-community/molecule/issues/3021

Previously, os_walk would not follow symlinks. This would break scenarios where you place tests in a common test directory.

For example the following directory structure:

```
molecule
├── common
│   └── unit
│       ├── test_ldap.py
│       └── test_zabbix.py
├── default
│   ├── conftest.py
│   ├── converge.yml
│   ├── create.yml
│   ├── Dockerfile.j2
│   ├── INSTALL.rst
│   ├── molecule.yml
│   ├── prepare.yml
│   ├── requirements.yml
│   └── tests
│       ├── conftest.py
└── zabbix-4.4.9
    ├── converge.yml
    ├── create.yml
    ├── Dockerfile.j2
    ├── INSTALL.rst
    ├── molecule.yml
    ├── prepare.yml
    ├── requirements.yml
    └── tests
        ├── conftest.py
        └── unit -> ../../common/unit
```

When running `molecule verify -s zabbix-4.4.9` no tests would be found. 