### PR TITLE
Allow including YAML files

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -306,6 +306,9 @@ project.
 Sharing Across Scenarios
 ========================
 
+Sharing whole files
+-------------------
+
 Playbooks and tests can be shared across scenarios.
 
 .. code-block:: bash
@@ -354,6 +357,30 @@ In this second example the actions `create`, `destroy`,
         prepare: ../resources/playbooks/prepare.yml
 
 .. _parallel-usage-example:
+
+Sharing YAML sections
+---------------------
+
+Portions of YAML files can be isolated and included in
+other files. For instance, you can create a file ``provisioner.yml``:
+
+.. code-block:: yaml
+
+    name: ansible
+    playbooks:
+      create: ../resources/playbooks/create.yml
+      destroy: ../resources/playbooks/destroy.yml
+      converge: ../resources/playbooks/converge.yml
+      prepare: ../resources/playbooks/prepare.yml
+
+The file can therefore be used in a scenario using:
+
+.. code-block:: yaml
+
+    provisioner: !include provisioner.yml
+
+Molecule will look for files relatively to the directory
+of the file that is currently being loaded.
 
 Running Molecule processes in parallel mode
 ===========================================

--- a/src/molecule/model/schema_v3.py
+++ b/src/molecule/model/schema_v3.py
@@ -21,8 +21,9 @@
 
 import collections
 import functools
+import pathlib
 import re
-from typing import Any, MutableMapping
+from typing import Any, MutableMapping, Optional
 
 import cerberus
 import cerberus.errors
@@ -367,9 +368,14 @@ class Validator(cerberus.Validator):
                 self._error(field, msg)
 
 
-def pre_validate(stream, env: MutableMapping, keep_string: str):
+def pre_validate(
+    stream,
+    env: MutableMapping,
+    keep_string: str,
+    include_path: Optional[pathlib.Path] = None,
+):
     """Pre-validate stream."""
-    data = util.safe_load(stream)
+    data = util.safe_load(stream, include_path=include_path)
 
     v = Validator(allow_unknown=True)
     v.validate(data, pre_validate_base_schema(env, keep_string))

--- a/src/molecule/test/conftest.py
+++ b/src/molecule/test/conftest.py
@@ -100,6 +100,11 @@ def get_molecule_file(path):
 
 
 @pytest.helpers.register
+def platforms_include_file():
+    return os.path.join(molecule_scenario_directory(), "platforms.yml")
+
+
+@pytest.helpers.register
 def molecule_ephemeral_directory(_fixture_uuid):
     project_directory = "test-project-{}".format(_fixture_uuid)
     scenario_name = "test-instance"

--- a/src/molecule/test/unit/test_config.py
+++ b/src/molecule/test/unit/test_config.py
@@ -97,11 +97,6 @@ def test_dependency_property_is_shell(config_instance):
     assert isinstance(config_instance.dependency, shell.Shell)
 
 
-@pytest.fixture
-def _config_driver_delegated_section_data():
-    return {"driver": {"name": "delegated", "options": {"managed": False}}}
-
-
 def test_env(config_instance):
     config_instance.args = {"env_file": ".env"}
     x = {
@@ -286,7 +281,9 @@ def test_preflight(mocker, config_instance, patched_logger_info):
 
     config_instance._preflight("foo")
 
-    m.assert_called_once_with("foo", os.environ, config.MOLECULE_KEEP_STRING)
+    m.assert_called_once_with(
+        "foo", os.environ, config.MOLECULE_KEEP_STRING, include_path=None
+    )
 
 
 def test_preflight_exists_when_validation_fails(


### PR DESCRIPTION
When using multiple scenarios with many platforms, we either need to duplicate the entries in every scenario or provide a base config. The latter does not really provide fine-grained granularity. Being able to include YAML files allows to share only some specific sections between scenarios.

#### PR Type

- Feature Pull Request
