### PR TITLE
Update ci.rst GitHub Actions Docker already installed

### DIFF
--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -38,7 +38,6 @@ and run ``molecule test`` in ubuntu.
             python-version: ${{ matrix.python-version }}
         - name: Install dependencies
           run: |
-            sudo apt install docker
             python3 -m pip install --upgrade pip
             python3 -m pip install -r requirements.txt
         - name: Test with molecule


### PR DESCRIPTION
##### SUMMARY
Docker is already installed in GitHub Actions ubuntu-latest environment (see https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md). An extra `sudo apt install docker` as suggested in the current docs leads to the following error `Unable to locate an executable at "/Library/Java/JavaVirtualMachines/adoptopenjdk-14.jdk/Contents/Home/bin/apt" (-1)` (see this build https://github.com/jonashackt/molecule-ansible-docker-aws/runs/1970452140?check_suite_focus=true). So we can safely remove the command to install docker.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

Please include details of what it is, how to use it, how it's been tested

Has been tested here: https://github.com/jonashackt/molecule-ansible-docker-aws/runs/1970537283?check_suite_focus=true

#### PR Type

- Docs Pull Request
