### PR TITLE
Assure molecule uses root logger

### DIFF
--- a/src/molecule/logger.py
+++ b/src/molecule/logger.py
@@ -44,7 +44,9 @@ def configure() -> None:
 
     All other loggers will inherit the configuration we set here.
     """
-    logger = logging.getLogger("molecule")
+    # Keep using root logger because we do want to process messages from other
+    # libraries.
+    logger = logging.getLogger()
     handler = RichHandler(
         console=console, show_time=False, show_path=False, markup=True
     )  # type: ignore


### PR DESCRIPTION
Instead of using a names "molecule" logger, we configure the root logger so we do not lose messages produced by other modules.

