### PR TITLE
Reformat source files with black

### DIFF
--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -87,7 +87,7 @@ class Idempotence(base.Base):
             LOG.info(msg)
         else:
             msg = (
-                "Idempotence test failed because of the following tasks:\n" u"{}"
+                "Idempotence test failed because of the following tasks:\n{}"
             ).format("\n".join(self._non_idempotent_tasks(output)))
             util.sysexit_with_message(msg)
 
@@ -132,7 +132,7 @@ class Idempotence(base.Base):
             elif line.startswith("changed"):
                 host_name = re.search(r"\[(.*)\]", line).groups()[0]
                 task_name = re.search(r"\[(.*)\]", task_line).groups()[0]
-                res.append(u"* [{}] => {}".format(host_name, task_name))
+                res.append("* [{}] => {}".format(host_name, task_name))
 
         return res
 


### PR DESCRIPTION
The latest black version changed a few formatting rules, causing the lint stage to fail. Changes in this commit make sure black is happy again.

#### PR Type

- Bugfix Pull Request
