### PR TITLE
Make sure we detect dependency installation failure

### DIFF
--- a/src/molecule/dependency/base.py
+++ b/src/molecule/dependency/base.py
@@ -23,8 +23,9 @@ import abc
 import logging
 import os
 import time
+from subprocess import CalledProcessError
 
-from molecule import constants, util
+from molecule import util
 
 LOG = logging.getLogger(__name__)
 
@@ -53,11 +54,11 @@ class Base(object):
 
         try:
             # print(555, self._sh_command)
-            util.run_command(self._sh_command, debug=self._config.debug)
+            util.run_command(self._sh_command, debug=self._config.debug, check=True)
             msg = "Dependency completed successfully."
             LOG.info(msg)
             return
-        except Exception:
+        except CalledProcessError:
             pass
 
         for counter in range(1, (self.RETRY + 1)):
@@ -70,15 +71,15 @@ class Base(object):
             self.SLEEP += self.BACKOFF
 
             try:
-                util.run_command(self._sh_command, debug=self._config.debug)
+                util.run_command(self._sh_command, debug=self._config.debug, check=True)
                 msg = "Dependency completed successfully."
                 LOG.info(msg)
                 return
-            except Exception as _exception:
+            except CalledProcessError as _exception:
                 exception = _exception
 
-        LOG.error(str(exception), self._sh_command)
-        util.sysexit(getattr(exception, "exit_code", constants.RC_UNKNOWN_ERROR))
+        LOG.error(str(exception))
+        util.sysexit(exception.returncode)
 
     @abc.abstractmethod
     def execute(self):  # pragma: no cover

--- a/src/molecule/test/unit/dependency/ansible_galaxy/test_collections.py
+++ b/src/molecule/test/unit/dependency/ansible_galaxy/test_collections.py
@@ -160,7 +160,9 @@ def test_execute(
     )
     assert os.path.isdir(role_directory)
 
-    patched_run_command.assert_called_once_with("patched-command", debug=False)
+    patched_run_command.assert_called_once_with(
+        "patched-command", debug=False, check=True
+    )
 
     msg = "Dependency completed successfully."
     patched_logger_info.assert_called_once_with(msg)

--- a/src/molecule/test/unit/dependency/ansible_galaxy/test_roles.py
+++ b/src/molecule/test/unit/dependency/ansible_galaxy/test_roles.py
@@ -156,7 +156,9 @@ def test_execute(
     )
     assert os.path.isdir(role_directory)
 
-    patched_run_command.assert_called_once_with("patched-command", debug=False)
+    patched_run_command.assert_called_once_with(
+        "patched-command", debug=False, check=True
+    )
 
     msg = "Dependency completed successfully."
     patched_logger_info.assert_called_once_with(msg)

--- a/src/molecule/test/unit/dependency/test_shell.py
+++ b/src/molecule/test/unit/dependency/test_shell.py
@@ -94,7 +94,9 @@ def test_execute(patched_run_command, patched_logger_info, _instance):
     _instance._sh_command = "patched-command"
     _instance.execute()
 
-    patched_run_command.assert_called_once_with("patched-command", debug=False)
+    patched_run_command.assert_called_once_with(
+        "patched-command", debug=False, check=True
+    )
 
     msg = "Dependency completed successfully."
     patched_logger_info.assert_called_once_with(msg)


### PR DESCRIPTION
Right now, we just ignore the failure because we do not check the return code of the children's process. This commit just makes sure we are notified when the dependency command fails.

Fixes #3070

#### PR Type

- Bugfix Pull Request
