### PR TITLE
fix(deps): add compatibility for click 8.0 via click-help-colors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,9 +68,9 @@ setup_requires =
 install_requires =
     ansible-lint >= 5.0.5  # only for the prerun functionality
     cerberus >= 1.3.1
-    click >= 7.0, < 8.0  # https://github.com/click-contrib/click-help-colors/issues/12
+    click >= 7.0
     click-completion >= 0.5.1
-    click-help-colors >= 0.6
+    click-help-colors >= 0.9
     cookiecutter >= 1.6.0, != 1.7.1
     dataclasses; python_version<"3.7"
     enrich >= 1.2.5


### PR DESCRIPTION
The incompatibility was marked in 0650abe7dd3bed5e477f91adefe26630cee22da0
as click-help-colors was not compatible. In the meanwhile version 0.9
added compatibility via https://github.com/click-contrib/click-help-colors/commit/00cdd2ca327624a8db4b5706d86b8e66da5c9dc6