### PR TITLE
fix(deps): cookiecutter conflicts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ install_requires =
     click >= 7.0
     click-completion >= 0.5.1
     click-help-colors >= 0.9
-    cookiecutter >= 1.6.0, != 1.7.1
+    cookiecutter >= 1.7.3  # dependency issues in older versions
     dataclasses; python_version<"3.7"
     enrich >= 1.2.5
     Jinja2 >= 2.10.1


### PR DESCRIPTION
Use the latest release of cookiecutter which sorts some dependency installation issues, like https://dashboard.zuul.ansible.com/t/ansible/build/5fed5830fe9049f3978108623024fb85
```
cookiecutter 1.7.2 has requirement Jinja2<3.0.0, but you have jinja2 3.0.0.
cookiecutter 1.7.2 has requirement MarkupSafe<2.0.0, but you have markupsafe 2.0.0.
```
