### PR TITLE
Fix ansible_ssh_common_args in molecule.yml

### DIFF
--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -171,7 +171,10 @@ class Delegated(Driver):
     @property
     def default_ssh_connection_options(self):
         if self.managed:
-            return self._get_ssh_connection_options()
+            ssh_connopts = self._get_ssh_connection_options()
+            if self.options.get("ansible_connection_options", {}).get("ansible_ssh_common_args", None):
+                ssh_connopts.append(self.options.get("ansible_connection_options").get("ansible_ssh_common_args"))
+            return ssh_connopts
         return []
 
     def login_options(self, instance_name):

--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -172,8 +172,14 @@ class Delegated(Driver):
     def default_ssh_connection_options(self):
         if self.managed:
             ssh_connopts = self._get_ssh_connection_options()
-            if self.options.get("ansible_connection_options", {}).get("ansible_ssh_common_args", None):
-                ssh_connopts.append(self.options.get("ansible_connection_options").get("ansible_ssh_common_args"))
+            if self.options.get("ansible_connection_options", {}).get(
+                "ansible_ssh_common_args", None
+            ):
+                ssh_connopts.append(
+                    self.options.get("ansible_connection_options").get(
+                        "ansible_ssh_common_args"
+                    )
+                )
             return ssh_connopts
         return []
 


### PR DESCRIPTION
Makes the option `ansible_ssh_common_args` in molecule.yml work as documented:

```yaml

        driver:
          name: delegated
          options:
            managed: True
            ansible_connection_options:
              ansible_connection: ssh
              ansible_ssh_common_args: '-F /path/to/ssh-config'
```

Fixes: #2859 
Fixes: #2931 