### PR TITLE
Deal with trailing colons on ANSIBLE_LIBRARY

### DIFF
--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -940,7 +940,7 @@ class Ansible(base.Base):
         )
 
         if os.environ.get("ANSIBLE_LIBRARY"):
-            paths.extend(map(util.abs_path, os.environ["ANSIBLE_LIBRARY"].split(":")))
+            paths.extend(map(util.abs_path, os.environ["ANSIBLE_LIBRARY"].strip(":").split(":")))
 
         return paths
 


### PR DESCRIPTION
```
In [1]: "plugins/modules:other/path:".split(":")
Out[1]: ['plugins/modules', 'other/path', '']

In [2]: ":plugins/modules:other/path:".split(":")
Out[2]: ['', 'plugins/modules', 'other/path', '']

In [3]: ":plugins/modules:other/path".split(":")
Out[3]: ['', 'plugins/modules', 'other/path']

In [4]: ":plugins/modules:other/path:".strip(":").split(":")
Out[4]: ['plugins/modules', 'other/path']

In [5]: "plugins/modules:other/path".strip(":").split(":")
Out[5]: ['plugins/modules', 'other/path']
```
`_update_env` may yield trailing colons, e.g. :plugins/modules
https://github.com/ansible-community/ansible-lint/blob/fd4b54ad17ed73d35c2757d80396c075f05ce3d0/src/ansiblelint/prerun.py#L321-L328

Error from CI:
```
 File "/opt/hostedtoolcache/Python/3.9.5/x64/lib/python3.9/site-packages/molecule/provisioner/ansible.py", line 465, in default_env
    "ANSIBLE_LIBRARY": ":".join(self._get_modules_directories()),
TypeError: sequence item 5: expected str instance, NoneType found
```
https://github.com/pulp/pulp_installer/runs/2602566475?check_suite_focus=true#step:8:3032

#### PR Type

- Bugfix Pull Request
