### PR TITLE
Require ansible-lint 5.0.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         entry: mypy src/
         pass_filenames: false
         additional_dependencies:
-          - ansible-lint>=5.0.5
+          - ansible-lint>=5.0.9
           - packaging
           - enrich>=1.2.5
           - subprocess-tee>=0.2.0
@@ -63,7 +63,7 @@ repos:
     hooks:
       - id: pylint
         additional_dependencies:
-          - ansible-lint>=5.0.5
+          - ansible-lint>=5.0.9
           - enrich>=1.2.5
           - subprocess-tee>=0.2.0
           - testinfra

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible-lint >= 5.0.5  # only for the prerun functionality
+    ansible-lint >= 5.0.9  # only for the prerun functionality
     cerberus >= 1.3.1, !=1.3.3, !=1.3.4
     click >= 8.0, < 9
     click-help-colors >= 0.9


### PR DESCRIPTION
In order to make use of the newer logic regarding preinstalling requirements bump version of ansible-lint used.

Fixes: #3055
