### PR TITLE
Avoid using in-repo .cache folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         entry: mypy src/
         pass_filenames: false
         additional_dependencies:
-          - ansible-lint>=5.0.9
+          - ansible-lint>=5.0.10
           - packaging
           - enrich>=1.2.5
           - subprocess-tee>=0.2.0
@@ -63,7 +63,7 @@ repos:
     hooks:
       - id: pylint
         additional_dependencies:
-          - ansible-lint>=5.0.9
+          - ansible-lint>=5.0.10
           - enrich>=1.2.5
           - subprocess-tee>=0.2.0
           - testinfra

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible-lint >= 5.0.9  # only for the prerun functionality
+    ansible-lint >= 5.0.10  # only for the prerun functionality
     cerberus >= 1.3.1, !=1.3.3, !=1.3.4
     click >= 8.0, < 9
     click-help-colors >= 0.9


### PR DESCRIPTION
Bump ansible-lint dependency to 5.0.10 in order to make use of the
https://github.com/ansible-community/ansible-lint/pull/1567 which
basically moves the tmp folder to use ~/.cache, avoiding
https://github.com/pypa/pip/issues/10005
