### PR TITLE
Added missing option name to `molecule init`

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -32,7 +32,7 @@ To generate a new role with Molecule, simply run:
 
 .. code-block:: bash
 
-    $ molecule init role my-new-role --driver-name docker
+    $ molecule init role --role-name my-new-role --driver-name docker
 
 You should then see a ``my-new-role`` folder in your current directory.
 


### PR DESCRIPTION
The `molecule init` command doesn't work as written.

#### PR Type

- Docs Pull Request

