### PR TITLE
Change ANSIBLE_LIBRARY PATH processing

### DIFF
--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -915,7 +915,13 @@ class Ansible(base.Base):
 
         Adds modules directory from molecule and its plugins.
         """
-        paths = [util.abs_path(os.path.join(self._get_plugin_directory(), "modules"))]
+        paths = list()
+        if os.environ.get("ANSIBLE_LIBRARY"):
+            paths = list(map(util.abs_path, os.environ["ANSIBLE_LIBRARY"].split(":")))
+
+        paths.append(
+            util.abs_path(os.path.join(self._get_plugin_directory(), "modules"))
+        )
 
         for d in drivers():
             p = d.modules_dir()
@@ -938,9 +944,6 @@ class Ansible(base.Base):
                 "/usr/share/ansible/plugins/modules",
             ]
         )
-
-        if os.environ.get("ANSIBLE_LIBRARY"):
-            paths.extend(map(util.abs_path, os.environ["ANSIBLE_LIBRARY"].split(":")))
 
         return paths
 

--- a/src/molecule/test/unit/provisioner/test_ansible.py
+++ b/src/molecule/test/unit/provisioner/test_ansible.py
@@ -704,7 +704,7 @@ def test_get_modules_directories_single_ansible_library(_instance, monkeypatch):
     paths = _instance._get_modules_directories()
 
     assert len(paths) == 6
-    assert paths[-1] == "/abs/path/lib"
+    assert paths[0] == "/abs/path/lib"
 
 
 def test_get_modules_directories_multi_ansible_library(_instance, monkeypatch):
@@ -713,8 +713,8 @@ def test_get_modules_directories_multi_ansible_library(_instance, monkeypatch):
     paths = _instance._get_modules_directories()
 
     assert len(paths) == 7
-    assert paths[-2].endswith("relpath/lib")
-    assert paths[-1] == "/abs/path/lib"
+    assert paths[0].endswith("relpath/lib")
+    assert paths[1] == "/abs/path/lib"
 
 
 def test_get_filter_plugin_directory(_instance):


### PR DESCRIPTION
When the environment variable ANSIBLE_LIBRARY is used, molecule is
currently extending the path with the contents of the found variable,
however, this will cause problems as the system driven path will
conflict with a user defined path. To correct this issue the path
processing will now insert the user provided variable into the path.

Signed-off-by: Kevin Carter <kecarter@redhat.com>

Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request