### PR TITLE
fix docs jobs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
-    "sphinx_ansible_theme.ext.pygments_lexer",
+    "sphinx_ansible_theme",
     "notfound.extension",
 ]
 


### PR DESCRIPTION
The docs jobs are broken because the docs configuration is using a module that no
longer exists. This change corrects that problem.

Signed-off-by: Kevin Carter <kecarter@redhat.com>

Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request
