### PR TITLE
Fix testing of collections checkouts

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -109,7 +109,7 @@ def execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args=()
 
         if scenario.config.config["prerun"]:
             LOG.info("Performing prerun...")
-            prepare_environment()
+            prepare_environment([],scenario.ephemeral_directory)
 
         if command_args.get("subcommand") == "reset":
             LOG.info("Removing %s" % scenario.ephemeral_directory)

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -432,6 +432,8 @@ class Ansible(base.Base):
                 ),
                 "/usr/share/ansible/collections",
                 "/etc/ansible/collections",
+                *os.environ.get("ANSIBLE_COLECTIONS_PATH", "").split(":"),
+                *os.environ.get("ANSIBLE_COLECTIONS_PATHS", "").split(":"),
             ]
         )
         env = util.merge_dicts(

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -432,8 +432,8 @@ class Ansible(base.Base):
                 ),
                 "/usr/share/ansible/collections",
                 "/etc/ansible/collections",
-                *os.environ.get("ANSIBLE_COLECTIONS_PATH", "").split(":"),
-                *os.environ.get("ANSIBLE_COLECTIONS_PATHS", "").split(":"),
+                *os.environ.get("ANSIBLE_COLLECTIONS_PATH", "").split(":"),
+                *os.environ.get("ANSIBLE_COLLECTIONS_PATHS", "").split(":"),
             ]
         )
         env = util.merge_dicts(


### PR DESCRIPTION
I have detailed documentation on the collection issue finally narrowed down.

https://github.com/provenvelocity/devops_test/tree/Collections_issue.

The issue is ansible is not aware of the current collection your in. This was fixed in ansible-lint by coping over the current collection. This fix allows molecule to change the cache_dir for lint and then better-integrated ansible lint with molecule. 

I know there is a long-term fix in the works but this will bridge the gaps. 

#### PR Type

- Bugfix Pull Request

#### This Fixes the following issue:

https://github.com/ansible-community/molecule/issues/3135

It Relies on this issue being fixed. 

https://github.com/ansible-community/ansible-lint/issues/1641
