### PR TITLE
Fix pip documentation link

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,7 +34,7 @@ Ubuntu 16.x
 Pip
 ===
 
-:std:doc:`pip <pip:usage>` is the only supported installation method.
+:std:doc:`pip <pip:getting-started>` is the only supported installation method.
 
 .. warning::
 


### PR DESCRIPTION
Pip's documentation has been rearranged a bit, including the usage document that the Molecule documentation pointed to. This commit updated the link so that it now points to the quickstart document.

#### PR Type

- Docs Pull Request
