### PR TITLE
Run functional tests in serial

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,7 @@ repos:
           - tenacity
           - types-PyYAML
           - types-dataclasses
+          - types-filelock
           - types-setuptools
   - repo: https://github.com/PyCQA/pylint
     rev: v2.11.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,34 @@ skip-string-normalization = false
 profile = "black"
 known_first_party = "molecule"
 
+[tool.pytest.ini_options]
+markers = [
+    "serial: Run this test serially via filelock.",
+    "extensive: marks tests that we want to skip by default, as they are indirectly covered by other tests"
+]
+norecursedirs = [
+  ".eggs",
+  ".tox",
+  "build",
+  "dist",
+  "doc",
+  "src/molecule/cookiecutter/scenario",
+  "src/molecule/test/resources",
+  "src/molecule/test/scenarios",
+]
+
+addopts = "--doctest-modules --durations 10 --color=yes"
+doctest_optionflags = [
+  "ALLOW_UNICODE",
+  "ELLIPSIS"
+]
+junit_suite_name = "molecule_test_suite"
+testpaths = "src/molecule/test/"
+filterwarnings = [
+    # treat warnings as errors unless we add them below
+    "error"
+    # ignore::UserWarning
+]
+
 [tool.setuptools_scm]
 local_scheme = "no-local-version"

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,19 +132,6 @@ molecule.verifier =
 [options.packages.find]
 where = src
 
-[tool:pytest]
-addopts = --doctest-modules --durations 10 --color=yes
-doctest_optionflags = ALLOW_UNICODE ELLIPSIS
-junit_suite_name = molecule_test_suite
-norecursedirs = dist doc build .tox .eggs src/molecule/test/scenarios src/molecule/test/resources
-testpaths = src/molecule/test/
-filterwarnings =
-    # treat warnings as errors unless we add them below
-    error
-    # ignore::UserWarning
-markers =
-    extensive: marks tests that we want to skip by default, as they are indirectly covered by other tests
-
 [flake8]
 # do not add excludes for files in repo
 exclude = .venv/,.tox/,dist/,build/,.eggs/

--- a/src/molecule/test/conftest.py
+++ b/src/molecule/test/conftest.py
@@ -24,6 +24,7 @@ import random
 import string
 
 import pytest
+from filelock import FileLock
 
 from molecule import config
 from molecule.scenario import ephemeral_directory
@@ -138,3 +139,14 @@ def reset_pytest_vars(monkeypatch):
     for var_name in tuple(os.environ):
         if var_name.startswith("PYTEST_"):
             monkeypatch.delenv(var_name, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def block_on_serial_mark(request):
+    # https://github.com/pytest-dev/pytest-xdist/issues/385
+    os.makedirs(".tox", exist_ok=True)
+    if request.node.get_closest_marker("serial"):
+        with FileLock(".tox/semaphore.lock"):
+            yield
+    else:
+        yield

--- a/src/molecule/test/functional/test_command.py
+++ b/src/molecule/test/functional/test_command.py
@@ -77,6 +77,7 @@ def test_command_check(scenario_to_test, with_scenario, scenario_name):
     ],
     indirect=["scenario_to_test", "driver_name", "scenario_name"],
 )
+@pytest.mark.serial
 def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "cleanup", "--scenario-name", scenario_name]
     assert run_command(cmd).returncode == 0
@@ -90,6 +91,7 @@ def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
     ],
     indirect=["scenario_to_test", "driver_name", "scenario_name"],
 )
+@pytest.mark.serial
 def test_command_converge(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "converge", "--scenario-name", scenario_name]
     assert run_command(cmd).returncode == 0
@@ -103,6 +105,7 @@ def test_command_converge(scenario_to_test, with_scenario, scenario_name):
     ],
     indirect=["scenario_to_test", "driver_name", "scenario_name"],
 )
+@pytest.mark.serial
 def test_command_create(scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "create", "--scenario-name", scenario_name]
     assert run_command(cmd).returncode == 0
@@ -132,6 +135,7 @@ def test_command_create(scenario_to_test, with_scenario, scenario_name):
     ],
     indirect=["scenario_to_test", "driver_name", "scenario_name"],
 )
+@pytest.mark.serial
 def test_command_dependency(request, scenario_to_test, with_scenario, scenario_name):
     cmd = ["molecule", "dependency", "--scenario-name", scenario_name]
     assert run_command(cmd, echo=True).returncode == 0
@@ -141,6 +145,7 @@ def test_command_dependency(request, scenario_to_test, with_scenario, scenario_n
     assert run_command(cmd, echo=True).returncode == 0
 
 
+@pytest.mark.serial
 @pytest.mark.extensive
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, scenario_name",
@@ -152,6 +157,7 @@ def test_command_destroy(scenario_to_test, with_scenario, scenario_name):
     assert run_command(cmd).returncode == 0
 
 
+@pytest.mark.serial
 @pytest.mark.extensive
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, scenario_name",
@@ -164,18 +170,21 @@ def test_command_idempotence(scenario_to_test, with_scenario, scenario_name):
     idempotence(scenario_name)
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize("driver_name", [("delegated")], indirect=["driver_name"])
 @pytest.mark.xfail(reason="https://github.com/ansible-community/molecule/issues/3171")
 def test_command_init_role(temp_dir, driver_name, skip_test):
     init_role(temp_dir, driver_name)
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize("driver_name", [("delegated")], indirect=["driver_name"])
 @pytest.mark.xfail(reason="https://github.com/ansible-community/molecule/issues/3171")
 def test_command_init_scenario(temp_dir, driver_name, skip_test):
     init_scenario(temp_dir, driver_name)
 
 
+@pytest.mark.serial
 @pytest.mark.extensive
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, scenario_name",
@@ -189,6 +198,7 @@ def test_command_lint(scenario_to_test, with_scenario, scenario_name):
     assert run_command(cmd).returncode == 0
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, expected",
     [
@@ -220,6 +230,7 @@ def test_command_list_with_format_plain(scenario_to_test, with_scenario, expecte
 #     login(login_args, scenario_name)
 
 
+@pytest.mark.serial
 @pytest.mark.extensive
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, scenario_name",
@@ -236,6 +247,7 @@ def test_command_prepare(scenario_to_test, with_scenario, scenario_name):
     assert run_command(cmd).returncode == 0
 
 
+@pytest.mark.serial
 @pytest.mark.extensive
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, scenario_name",
@@ -249,6 +261,7 @@ def test_command_side_effect(scenario_to_test, with_scenario, scenario_name):
     assert run_command(cmd).returncode == 0
 
 
+@pytest.mark.serial
 @pytest.mark.extensive
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, scenario_name",
@@ -262,6 +275,7 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     assert run_command(cmd).returncode == 0
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, scenario_name",
     [
@@ -273,6 +287,7 @@ def test_command_test(scenario_to_test, with_scenario, scenario_name, driver_nam
     run_test(driver_name, scenario_name)
 
 
+@pytest.mark.serial
 @pytest.mark.extensive
 @pytest.mark.parametrize(
     "scenario_to_test, driver_name, scenario_name",

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ setenv =
     PIP_DISABLE_PIP_VERSION_CHECK=1
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1
-    _EXTRAS=-l --cov=molecule --no-cov-on-fail --cov-report xml:{envlogdir}/coverage.xml --html={envlogdir}/reports.html --self-contained-html
+    _EXTRAS=-l -n auto --cov=molecule --no-cov-on-fail --cov-report xml:{envlogdir}/coverage.xml --html={envlogdir}/reports.html --self-contained-html
 deps =
     --editable .[docker,lint,podman,test,windows]
     devel: git+https://github.com/ansible/ansible#egg=ansible-core
@@ -66,7 +66,6 @@ commands =
     pip check
     # failsafe for preventing changes that may break pytest collection
     sh -c "PYTEST_ADDOPTS= python -m pytest -p no:cov --collect-only"
-    # -n auto used only on unit as is not supported by functional yet
     # html report is used by Zuul CI to display reports
     python -m pytest {env:_EXTRAS} {env:PYTEST_ADDOPTS:} {posargs}
 
@@ -198,7 +197,7 @@ deps =
     molecule-openstack >= 0.3
     molecule-podman >= 1.0.1
     molecule-vagrant >= 0.6.1
-    tox-ansible >= 1.1.0
+    tox-ansible >= 1.5.1
     pipdeptree >= 2.0.0
 commands =
     pip check


### PR DESCRIPTION
This change allows us to run tests in parallel using xdist while keeping the functional tests that are known to fail serial.

Related: https://github.com/pytest-dev/pytest-xdist/issues/385
