### PR TITLE
Use portable cache from ansible-compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         entry: mypy src/
         pass_filenames: false
         additional_dependencies:
-          - ansible-compat>=0.4.0
+          - ansible-compat>=0.5.0
           - click>=8.0.1
           - enrich>=1.2.5
           - importlib-metadata>=4.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible-compat >= 0.4.0
+    ansible-compat >= 0.5.0
     cerberus >= 1.3.1, !=1.3.3, !=1.3.4
     click >= 8.0, < 9
     click-help-colors >= 0.9
@@ -99,9 +99,9 @@ docs =
     sphinx-notfound-page >= 0.7.1
     sphinx_ansible_theme >= 0.2.2
 docker =
-    molecule-docker
+    molecule-docker >= 1.0.0
 podman =
-    molecule-podman
+    molecule-podman >= 1.0.1
 windows =
     pywinrm
 test =

--- a/src/molecule/api.py
+++ b/src/molecule/api.py
@@ -5,9 +5,9 @@ import traceback
 from collections import UserList
 
 import pluggy
+from ansible_compat.ports import cache
 
 from molecule.driver.base import Driver  # noqa
-from molecule.util import lru_cache
 from molecule.verifier.base import Verifier  # noqa
 
 LOG = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ class IncompatibleMoleculeRuntimeWarning(MoleculeRuntimeWarning):
     """A warning noting an unsupported runtime environment."""
 
 
-@lru_cache()
+@cache
 def drivers(config=None) -> UserListMap:
     """Return list of active drivers."""
     plugins = UserListMap()
@@ -64,7 +64,7 @@ def drivers(config=None) -> UserListMap:
     return plugins
 
 
-@lru_cache()
+@cache
 def verifiers(config=None) -> UserListMap:
     """Return list of active verifiers."""
     plugins = UserListMap()

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -20,13 +20,13 @@
 """Config Module."""
 
 import copy
-import functools
 import logging
 import os
 import warnings
-from typing import Callable, MutableMapping, TypeVar
+from typing import MutableMapping
 from uuid import uuid4
 
+from ansible_compat.ports import cache, cached_property
 from ansible_compat.runtime import Runtime
 from packaging.version import Version
 
@@ -43,14 +43,6 @@ MOLECULE_DIRECTORY = "molecule"
 MOLECULE_FILE = "molecule.yml"
 MOLECULE_KEEP_STRING = "MOLECULE_"
 DEFAULT_DRIVER = "delegated"
-
-T = TypeVar("T")
-
-
-# see https://github.com/python/mypy/issues/5858
-def cache(func: Callable[..., T]) -> T:
-    """Decorate properties to cache them."""
-    return functools.lru_cache()(func)  # type: ignore
 
 
 @cache
@@ -169,8 +161,7 @@ class Config(object, metaclass=NewInitCaller):
     def molecule_directory(self):
         return molecule_directory(self.project_directory)
 
-    @property  # type: ignore  # see https://github.com/python/mypy/issues/1362
-    @util.lru_cache()
+    @cached_property
     def dependency(self):
         dependency_name = self.config["dependency"]["name"]
         if dependency_name == "galaxy":
@@ -178,8 +169,7 @@ class Config(object, metaclass=NewInitCaller):
         elif dependency_name == "shell":
             return shell.Shell(self)
 
-    @property  # type: ignore
-    @util.lru_cache()
+    @cached_property
     def driver(self):
         driver_name = self._get_driver_name()
         driver = None
@@ -209,36 +199,30 @@ class Config(object, metaclass=NewInitCaller):
             "MOLECULE_VERIFIER_TEST_DIRECTORY": self.verifier.directory,
         }
 
-    @property  # type: ignore
-    @util.lru_cache()
+    @cached_property
     def lint(self):
         lint_name = self.config.get("lint", None)
         return lint_name
 
-    @property  # type: ignore
-    @util.lru_cache()
+    @cached_property
     def platforms(self):
         return platforms.Platforms(self, parallelize_platforms=self.is_parallel)
 
-    @property  # type: ignore
-    @cache
+    @cached_property
     def provisioner(self):
         provisioner_name = self.config["provisioner"]["name"]
         if provisioner_name == "ansible":
             return ansible.Ansible(self)
 
-    @property  # type: ignore
-    @util.lru_cache()
+    @cached_property
     def scenario(self):
         return scenario.Scenario(self)
 
-    @property  # type: ignore
-    @util.lru_cache()
+    @cached_property
     def state(self):
         return state.State(self)
 
-    @property  # type: ignore
-    @util.lru_cache()
+    @cached_property
     def verifier(self):
         return api.verifiers(self).get(self.config["verifier"]["name"], None)
 

--- a/src/molecule/logger.py
+++ b/src/molecule/logger.py
@@ -22,9 +22,10 @@
 import logging
 import os
 import time
-from functools import lru_cache, wraps
+from functools import wraps
 from typing import Callable, Iterable
 
+from ansible_compat.ports import cache
 from enrich.logging import RichHandler
 
 from molecule.console import console, console_stderr
@@ -191,7 +192,7 @@ def section_logger(func: Callable) -> Callable:
     return wrapper
 
 
-@lru_cache()
+@cache
 def get_section_loggers() -> Iterable[Callable]:
     """Return a list of section wrappers to be added."""
     default_section_loggers = [section_logger]

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -26,6 +26,8 @@ import os
 import shutil
 from typing import List, Optional
 
+from ansible_compat.ports import cached_property
+
 from molecule import util
 from molecule.api import drivers
 from molecule.provisioner import ansible_playbook, ansible_playbooks, base
@@ -635,8 +637,7 @@ class Ansible(base.Base):
     def config_file(self):
         return os.path.join(self._config.scenario.ephemeral_directory, "ansible.cfg")
 
-    @property  # type: ignore
-    @util.lru_cache()
+    @cached_property
     def playbooks(self):
         return ansible_playbooks.AnsiblePlaybooks(self._config)
 

--- a/src/molecule/test/functional/conftest.py
+++ b/src/molecule/test/functional/conftest.py
@@ -27,6 +27,7 @@ from typing import Optional
 
 import pexpect
 import pytest
+from ansible_compat.ports import cache
 from ansible_compat.runtime import Runtime
 from packaging.version import Version
 
@@ -236,7 +237,7 @@ def get_virtualbox_executable():
     return shutil.which("VBoxManage")
 
 
-@util.lru_cache()
+@cache
 def supports_docker() -> bool:
     docker = get_docker_executable()
     if docker:

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -28,13 +28,13 @@ import os
 import re
 import sys
 from dataclasses import dataclass
-from functools import lru_cache  # noqa
 from subprocess import CalledProcessError, CompletedProcess
 from typing import Any, Dict, Iterable, List, MutableMapping, NoReturn, Optional, Union
 from warnings import WarningMessage
 
 import jinja2
 import yaml
+from ansible_compat.ports import cache
 from rich.syntax import Syntax
 from subprocess_tee import run
 
@@ -341,7 +341,7 @@ def _parallelize_platforms(config, run_uuid):
     return [parallelize(platform) for platform in config["platforms"]]
 
 
-@lru_cache()
+@cache
 def find_vcs_root(location="", dirs=(".git", ".hg", ".svn"), default=None) -> str:
     """Return current repository root directory."""
     if not location:

--- a/tox.ini
+++ b/tox.ini
@@ -189,18 +189,18 @@ extras =
     # we install test extra in order to validate it does not drag ansible in
     test
 deps =
-    ansible-base >= 2.10.6
+    ansible-core >= 2.11
     molecule-azure >= 0.5.0
-    molecule-containers >= 0.2.1
+    molecule-containers >= 1.0.0
     molecule-digitalocean >= 0.1
-    molecule-docker >= 0.2.4
+    molecule-docker >= 1.0.2
     molecule-ec2 >= 0.3
     molecule-gce >= 0.2
-    molecule-hetznercloud >= 1.0.0
+    molecule-hetznercloud >= 1.3.0
     molecule-libvirt >= 0.0.3
     molecule-lxd >= 0.2
     molecule-openstack >= 0.3
-    molecule-podman >= 0.3.0
+    molecule-podman >= 1.0.1
     molecule-vagrant >= 0.6.1
     tox-ansible >= 1.1.0
     pipdeptree >= 2.0.0


### PR DESCRIPTION
This simplifies use of caching across multiple versions of Python.
Implementation is inspired from the the approach taken by https://github.com/apache/airflow/ project.

Related: https://github.com/python/mypy/issues/1362