### PR TITLE
Update .pre-commit-config.yaml pylint repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,8 +58,8 @@ repos:
           - packaging
           - enrich>=1.2.5
           - subprocess-tee>=0.2.0
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.7.2
+  - repo: https://github.com/PyCQA/pylint
+    rev: pylint-2.7.2
     hooks:
       - id: pylint
         additional_dependencies:


### PR DESCRIPTION
According to https://github.com/pre-commit/mirrors-pylint readme `This mirror repository is deprecated, use pylint directly.`

The result is the mirrors-pylint repo is missing a bunch of tags that pylint has.

Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request
