### PR TITLE
feat: add MOLECULE_PROJECT_BASE_DIRECTORY environment variable

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -47,6 +47,8 @@ MOLECULE_EPHEMERAL_DIRECTORY      Path to generated directory, usually
                                   ``~/.cache/molecule/<scenario-name>``
 MOLECULE_SCENARIO_DIRECTORY       Path to scenario directory
 MOLECULE_PROJECT_DIRECTORY        Path to your project directory
+MOLECULE_PROJECT_BASE_DIRECTORY   Base project directory name, i.e. the latest
+                                  directory name in the project path.
 MOLECULE_INSTANCE_CONFIG          ?
 MOLECULE_DEPENDENCY_NAME          Dependency type name, usually 'galaxy'
 MOLECULE_DRIVER_NAME              Name of the molecule scenario driver

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -187,6 +187,7 @@ class Config(object, metaclass=NewInitCaller):
             "MOLECULE_EPHEMERAL_DIRECTORY": self.scenario.ephemeral_directory,
             "MOLECULE_SCENARIO_DIRECTORY": self.scenario.directory,
             "MOLECULE_PROJECT_DIRECTORY": self.project_directory,
+            "MOLECULE_PROJECT_BASE_DIRECTORY": os.path.basename(self.project_directory),
             "MOLECULE_INSTANCE_CONFIG": self.driver.instance_config,
             "MOLECULE_DEPENDENCY_NAME": self.dependency.name,
             "MOLECULE_DRIVER_NAME": self.driver.name,

--- a/src/molecule/test/unit/test_config.py
+++ b/src/molecule/test/unit/test_config.py
@@ -112,6 +112,9 @@ def test_env(config_instance):
         "MOLECULE_EPHEMERAL_DIRECTORY": config_instance.scenario.ephemeral_directory,
         "MOLECULE_SCENARIO_DIRECTORY": config_instance.scenario.directory,
         "MOLECULE_PROJECT_DIRECTORY": config_instance.project_directory,
+        "MOLECULE_PROJECT_BASE_DIRECTORY": os.path.basename(
+            config_instance.project_directory
+        ),
         "MOLECULE_INSTANCE_CONFIG": config_instance.driver.instance_config,
         "MOLECULE_DEPENDENCY_NAME": "galaxy",
         "MOLECULE_DRIVER_NAME": "delegated",


### PR DESCRIPTION
Simple PR to add a new `MOLECULE_` environment variable that contains the directory basename (not the absolute path) of the project directory.

This can be useful, for example, to create instances with unique dynamic names per project/collection/role... when the driver does not support slashes in the instance name or the resulting instance name would be too long to be readable.

I have not added neither `MOLECULE_SCENARIO_BASE_DIRECTORY` (as it would have the same value as `MOLECULE_SCENARIO_NAME`) nor `MOLECULE_EPHEMERAL_BASE_DIRECTORY` (as except when it is customized by the user, it also contains the scenario name).

#### PR Type

- Feature Pull Request
