### PR TITLE
Allow molecule drivers to require collections

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible-lint >= 5.0.12  # only for the prerun functionality
+    ansible-lint >= 5.1.1  # only for the prerun functionality
     cerberus >= 1.3.1, !=1.3.3, !=1.3.4
     click >= 8.0, < 9
     click-help-colors >= 0.9

--- a/src/molecule/dependency/ansible_galaxy/base.py
+++ b/src/molecule/dependency/ansible_galaxy/base.py
@@ -113,6 +113,7 @@ class AnsibleGalaxyBase(base.Base):
         )
 
     def execute(self):
+        super().execute()
         if not self.enabled:
             msg = "Skipping, dependency is disabled."
             LOG.warning(msg)

--- a/src/molecule/dependency/base.py
+++ b/src/molecule/dependency/base.py
@@ -25,6 +25,8 @@ import os
 import time
 from subprocess import CalledProcessError
 
+from ansiblelint.prerun import require_collection
+
 from molecule import util
 
 LOG = logging.getLogger(__name__)
@@ -88,6 +90,8 @@ class Base(object):
 
         :return: None
         """
+        for name, version in self._config.driver.required_collections.items():
+            require_collection(name, version)
 
     @property
     @abc.abstractmethod

--- a/src/molecule/dependency/shell.py
+++ b/src/molecule/dependency/shell.py
@@ -89,6 +89,7 @@ class Shell(base.Base):
         self._sh_command = BakedCommand(cmd=self.command, env=self.env)
 
     def execute(self):
+        super().execute()
         if not self.enabled:
             msg = "Skipping, dependency is disabled."
             LOG.warning(msg)

--- a/src/molecule/driver/base.py
+++ b/src/molecule/driver/base.py
@@ -22,6 +22,7 @@
 import inspect
 import os
 from abc import ABCMeta, abstractmethod
+from typing import Dict
 
 import pkg_resources
 
@@ -297,3 +298,8 @@ class Driver(object):
         by molecule, regardless the scenario name.  Molecule will use metadata
         like labels or tags to annotate resources allocated by it.
         """
+
+    @property
+    def required_collections(self) -> Dict[str, str]:
+        """Return collections dict containing names and versions required."""
+        return {}

--- a/src/molecule/shell.py
+++ b/src/molecule/shell.py
@@ -64,6 +64,10 @@ def print_version(ctx, param, value):
     )
     for driver in drivers():
         msg += f"\n    [repr.attrib_name]{str(driver)}[/][dim]:[/][repr.number]{driver.version}[/][dim] from {driver.module}[/]"
+        if driver.required_collections:
+            msg += " requiring collections:"
+            for name, version in driver.required_collections.items():
+                msg += f" {name}>={version}"
     console.print(msg)
 
     ctx.exit()


### PR DESCRIPTION
This change enables drivers to expose the list of required collections they need for running.

Molecule will display required collections for each driver as part of `molecule --version` listing.

During 'dependency' run molecule will check for presence of required collections and install/upgrade them if needed.

The need for this feature was discovered when newer versions of plugins like docker and podman started to require versions of their collections that do not ship with ansible 2.9. By checking presence of required collections at runtime, we can avoid confusing errors for the users.