### PR TITLE
Drop use of pytest-helpers-namespace

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,8 +6,6 @@ import os
 
 import pytest
 
-pytest_plugins = ["helpers_namespace"]
-
 
 @pytest.fixture(scope="session", autouse=True)
 def environ():

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,6 @@ test =
 
     pexpect >= 4.8.0, < 5
     pytest-cov >= 2.10.1
-    pytest-helpers-namespace >= 2019.1.8
     pytest-html >= 3.0.0
     pytest-mock >= 3.3.1
     pytest-plus >= 0.2

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -433,12 +433,12 @@ class Config(object, metaclass=NewInitCaller):
             util.sysexit_with_message(msg)
 
 
-def molecule_directory(path):
+def molecule_directory(path: str) -> str:
     """Return directory of the current scenario."""
     return os.path.join(path, MOLECULE_DIRECTORY)
 
 
-def molecule_file(path):
+def molecule_file(path: str) -> str:
     """Return file path of current scenario."""
     return os.path.join(path, MOLECULE_FILE)
 

--- a/src/molecule/test/conftest.py
+++ b/src/molecule/test/conftest.py
@@ -74,33 +74,27 @@ def resources_folder_path():
     return resources_folder_path
 
 
-@pytest.helpers.register
-def molecule_project_directory():
+def molecule_project_directory() -> str:
     return os.getcwd()
 
 
-@pytest.helpers.register
-def molecule_directory():
+def molecule_directory() -> str:
     return config.molecule_directory(molecule_project_directory())
 
 
-@pytest.helpers.register
-def molecule_scenario_directory():
+def molecule_scenario_directory() -> str:
     return os.path.join(molecule_directory(), "default")
 
 
-@pytest.helpers.register
-def molecule_file():
+def molecule_file() -> str:
     return get_molecule_file(molecule_scenario_directory())
 
 
-@pytest.helpers.register
-def get_molecule_file(path):
+def get_molecule_file(path: str) -> str:
     return config.molecule_file(path)
 
 
-@pytest.helpers.register
-def molecule_ephemeral_directory(_fixture_uuid):
+def molecule_ephemeral_directory(_fixture_uuid) -> str:
     project_directory = "test-project-{}".format(_fixture_uuid)
     scenario_name = "test-instance"
 

--- a/src/molecule/test/functional/test_command.py
+++ b/src/molecule/test/functional/test_command.py
@@ -18,8 +18,19 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-import pytest
+from typing import Optional
 
+import pytest
+from pytest import FixtureRequest
+
+from molecule.test.functional.conftest import (
+    idempotence,
+    init_role,
+    init_scenario,
+    list_with_format_plain,
+    run_test,
+    verify,
+)
 from molecule.util import run_command
 
 
@@ -37,8 +48,11 @@ def scenario_name(request):
 
 
 @pytest.fixture
-def driver_name(request):
-    return request.param
+def driver_name(request: FixtureRequest) -> Optional[str]:
+    try:
+        return request.param
+    except AttributeError:
+        return None
 
 
 @pytest.mark.extensive
@@ -146,19 +160,19 @@ def test_command_destroy(scenario_to_test, with_scenario, scenario_name):
     indirect=["scenario_to_test", "driver_name", "scenario_name"],
 )
 def test_command_idempotence(scenario_to_test, with_scenario, scenario_name):
-    pytest.helpers.idempotence(scenario_name)
+    idempotence(scenario_name)
 
 
 @pytest.mark.parametrize("driver_name", [("delegated")], indirect=["driver_name"])
 @pytest.mark.xfail(reason="https://github.com/ansible-community/molecule/issues/3171")
 def test_command_init_role(temp_dir, driver_name, skip_test):
-    pytest.helpers.init_role(temp_dir, driver_name)
+    init_role(temp_dir, driver_name)
 
 
 @pytest.mark.parametrize("driver_name", [("delegated")], indirect=["driver_name"])
 @pytest.mark.xfail(reason="https://github.com/ansible-community/molecule/issues/3171")
 def test_command_init_scenario(temp_dir, driver_name, skip_test):
-    pytest.helpers.init_scenario(temp_dir, driver_name)
+    init_scenario(temp_dir, driver_name)
 
 
 @pytest.mark.extensive
@@ -186,7 +200,7 @@ def test_command_lint(scenario_to_test, with_scenario, scenario_name):
     indirect=["scenario_to_test", "driver_name"],
 )
 def test_command_list_with_format_plain(scenario_to_test, with_scenario, expected):
-    pytest.helpers.list_with_format_plain(expected)
+    list_with_format_plain(expected)
 
 
 # @pytest.mark.parametrize(
@@ -202,7 +216,7 @@ def test_command_list_with_format_plain(scenario_to_test, with_scenario, expecte
 #     indirect=["scenario_to_test", "driver_name", "scenario_name"],
 # )
 # def test_command_login(scenario_to_test, with_scenario, login_args, scenario_name):
-#     pytest.helpers.login(login_args, scenario_name)
+#     login(login_args, scenario_name)
 
 
 @pytest.mark.extensive
@@ -255,7 +269,7 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     indirect=["scenario_to_test", "driver_name", "scenario_name"],
 )
 def test_command_test(scenario_to_test, with_scenario, scenario_name, driver_name):
-    pytest.helpers.test(driver_name, scenario_name)
+    run_test(driver_name, scenario_name)
 
 
 @pytest.mark.extensive
@@ -267,4 +281,4 @@ def test_command_test(scenario_to_test, with_scenario, scenario_name, driver_nam
     indirect=["scenario_to_test", "driver_name", "scenario_name"],
 )
 def test_command_verify(scenario_to_test, with_scenario, scenario_name):
-    pytest.helpers.verify(scenario_name)
+    verify(scenario_name)

--- a/src/molecule/test/unit/conftest.py
+++ b/src/molecule/test/unit/conftest.py
@@ -24,20 +24,25 @@ import os
 import shutil
 from pathlib import Path
 from subprocess import CompletedProcess
+from typing import Any, Tuple
 from uuid import uuid4
 
 import pytest
 
 from molecule import config, util
+from molecule.test.conftest import (
+    molecule_directory,
+    molecule_ephemeral_directory,
+    molecule_file,
+    molecule_scenario_directory,
+)
 
 
-@pytest.helpers.register
-def write_molecule_file(filename, data):
+def write_molecule_file(filename: str, data: Any) -> None:
     util.write_file(filename, util.safe_dump(data))
 
 
-@pytest.helpers.register
-def os_split(s):
+def os_split(s: str) -> Tuple[str, ...]:
     rest, tail = os.path.split(s)
     if rest in ("", os.path.sep):
         return (tail,)
@@ -109,12 +114,12 @@ def molecule_data(
 
 @pytest.fixture
 def molecule_directory_fixture(temp_dir):
-    return pytest.helpers.molecule_directory()
+    return molecule_directory()
 
 
 @pytest.fixture
 def molecule_scenario_directory_fixture(molecule_directory_fixture):
-    path = pytest.helpers.molecule_scenario_directory()
+    path = molecule_scenario_directory()
     if not os.path.isdir(path):
         os.makedirs(path)
 
@@ -123,7 +128,7 @@ def molecule_scenario_directory_fixture(molecule_directory_fixture):
 
 @pytest.fixture
 def molecule_ephemeral_directory_fixture(molecule_scenario_directory_fixture):
-    path = pytest.helpers.molecule_ephemeral_directory(str(uuid4()))
+    path = molecule_ephemeral_directory(str(uuid4()))
     if not os.path.isdir(path):
         os.makedirs(path)
     yield
@@ -134,7 +139,7 @@ def molecule_ephemeral_directory_fixture(molecule_scenario_directory_fixture):
 def molecule_file_fixture(
     molecule_scenario_directory_fixture, molecule_ephemeral_directory_fixture
 ):
-    return pytest.helpers.molecule_file()
+    return molecule_file()
 
 
 @pytest.fixture
@@ -144,7 +149,7 @@ def config_instance(
     mdc = copy.deepcopy(molecule_data)
     if hasattr(request, "param"):
         mdc = util.merge_dicts(mdc, request.getfixturevalue(request.param))
-    pytest.helpers.write_molecule_file(molecule_file_fixture, mdc)
+    write_molecule_file(molecule_file_fixture, mdc)
     c = config.Config(molecule_file_fixture)
     c.command_args = {"subcommand": "test"}
 

--- a/src/molecule/test/unit/provisioner/test_ansible.py
+++ b/src/molecule/test/unit/provisioner/test_ansible.py
@@ -26,6 +26,7 @@ import pytest
 
 from molecule import config, util
 from molecule.provisioner import ansible, ansible_playbooks
+from molecule.test.unit.conftest import os_split
 
 
 @pytest.fixture
@@ -319,7 +320,7 @@ def test_playbooks_property(_instance):
 
 def test_directory_property(_instance):
     result = _instance.directory
-    parts = pytest.helpers.os_split(result)
+    parts = os_split(result)
 
     assert ("molecule", "provisioner", "ansible") == parts[-3:]
 
@@ -680,7 +681,7 @@ def test_default_to_regular(_instance):
 
 def test_get_plugin_directory(_instance):
     result = _instance._get_plugin_directory()
-    parts = pytest.helpers.os_split(result)
+    parts = os_split(result)
 
     assert ("molecule", "provisioner", "ansible", "plugins") == parts[-4:]
 
@@ -719,7 +720,7 @@ def test_get_modules_directories_multi_ansible_library(_instance, monkeypatch):
 
 def test_get_filter_plugin_directory(_instance):
     result = _instance._get_filter_plugin_directory()
-    parts = pytest.helpers.os_split(result)
+    parts = os_split(result)
     x = ("molecule", "provisioner", "ansible", "plugins", "filter")
 
     assert x == parts[-5:]

--- a/src/molecule/test/unit/provisioner/test_ansible_playbooks.py
+++ b/src/molecule/test/unit/provisioner/test_ansible_playbooks.py
@@ -24,6 +24,7 @@ import pytest
 
 from molecule import util
 from molecule.provisioner import ansible_playbooks
+from molecule.test.unit.conftest import os_split
 
 
 @pytest.fixture
@@ -74,7 +75,7 @@ def test_verify_property(_instance):
 
 def test_get_playbook_directory(_instance):
     result = _instance._get_playbook_directory()
-    parts = pytest.helpers.os_split(result)
+    parts = os_split(result)
     x = ("molecule", "provisioner", "ansible", "playbooks")
 
     assert x == parts[-4:]
@@ -136,7 +137,7 @@ def test_get_ansible_playbook_with_driver_key_when_playbook_key_missing(
 
 def test_get_bundled_driver_playbook(_instance):
     result = _instance._get_bundled_driver_playbook("create")
-    parts = pytest.helpers.os_split(result)
+    parts = os_split(result)
     x = ("molecule", "driver", "playbooks", "create.yml")
 
     assert x == parts[-4:]

--- a/src/molecule/test/unit/test_util.py
+++ b/src/molecule/test/unit/test_util.py
@@ -29,6 +29,7 @@ import pytest
 from molecule import util
 from molecule.console import console
 from molecule.constants import MOLECULE_HEADER
+from molecule.test.conftest import get_molecule_file, molecule_directory
 from molecule.text import strip_ansi_escape
 
 
@@ -164,14 +165,14 @@ def test_run_command_with_debug_handles_no_env(mocker, patched_print_debug):
 
 def test_os_walk(temp_dir):
     scenarios = ["scenario1", "scenario2", "scenario3"]
-    molecule_directory = pytest.helpers.molecule_directory()
+    mol_dir = molecule_directory()
     for scenario in scenarios:
-        scenario_directory = os.path.join(molecule_directory, scenario)
-        molecule_file = pytest.helpers.get_molecule_file(scenario_directory)
+        scenario_directory = os.path.join(mol_dir, scenario)
+        molecule_file = get_molecule_file(scenario_directory)
         os.makedirs(scenario_directory)
         util.write_file(molecule_file, "")
 
-    result = [f for f in util.os_walk(molecule_directory, "molecule.yml")]
+    result = [f for f in util.os_walk(mol_dir, "molecule.yml")]
     assert 3 == len(result)
 
 


### PR DESCRIPTION
Related: https://github.com/saltstack/pytest-helpers-namespace/issues/10

This change is  marked as major because it will break testing of molecule drivers. They can easily be fixed to avoid using the removed helpers namespace.
