### PR TITLE
Made prune more resilient to filesystem errors

### DIFF
--- a/src/molecule/scenario.py
+++ b/src/molecule/scenario.py
@@ -128,13 +128,19 @@ class Scenario(object):
         ] + self.config.driver.safe_files
         files = util.os_walk(self.ephemeral_directory, "*")
         for f in files:
-            if not any(sf for sf in safe_files if fnmatch.fnmatch(f, sf)):
-                os.remove(f)
+            try:
+                if not any(sf for sf in safe_files if fnmatch.fnmatch(f, sf)):
+                    os.remove(f)
+            except FileNotFoundError:
+                pass
 
         # Remove empty directories.
         for dirpath, dirs, files in os.walk(self.ephemeral_directory, topdown=False):
             if not dirs and not files:
-                os.removedirs(dirpath)
+                try:
+                    os.removedirs(dirpath)
+                except OSError as exc:
+                    LOG.info("Failed to remove directory: %s", exc)
 
     @property
     def name(self):


### PR DESCRIPTION
Fixed observed problem with prune() where it would have failed due
to exceptions being raised during pruning.

This was observed occurring randomly while running tests with xdist.

Related: #3178