### PR TITLE
Bump jinja2 minimal version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ install_requires =
     cookiecutter >= 1.7.3  # dependency issues in older versions
     dataclasses; python_version<"3.7"
     enrich >= 1.2.5
-    Jinja2 >= 2.10.1
+    Jinja2 >= 2.11.3
     packaging
     paramiko >= 2.5.0, < 3
     pluggy >= 0.7.1, < 1.0


### PR DESCRIPTION
This should ensure that features like `is boolean` are available in jinja2 used by molecule.

Related: https://github.com/ansible-community/molecule-vagrant/pull/112