### PR TITLE
Capture sanity check warnings and display them

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,22 +27,22 @@ jobs:
           - tox_env: docs
             python-version: 3.9
           - tox_env: py36
-            PREFIX: PYTEST_REQPASS=448
+            PREFIX: PYTEST_REQPASS=449
             python-version: 3.6
           - tox_env: py37
-            PREFIX: PYTEST_REQPASS=448
+            PREFIX: PYTEST_REQPASS=449
             python-version: 3.7
           - tox_env: py38
-            PREFIX: PYTEST_REQPASS=448
+            PREFIX: PYTEST_REQPASS=449
             python-version: 3.8
           - tox_env: py39
-            PREFIX: PYTEST_REQPASS=448
+            PREFIX: PYTEST_REQPASS=449
             python-version: 3.9
           - tox_env: py36-devel
-            PREFIX: PYTEST_REQPASS=448
+            PREFIX: PYTEST_REQPASS=449
             python-version: 3.6
           - tox_env: py39-devel
-            PREFIX: PYTEST_REQPASS=448
+            PREFIX: PYTEST_REQPASS=449
             python-version: 3.9
           - tox_env: packaging
             python-version: 3.9

--- a/src/molecule/api.py
+++ b/src/molecule/api.py
@@ -36,6 +36,14 @@ class UserListMap(UserList):
         super(UserListMap, self).append(item)
 
 
+class MoleculeRuntimeWarning(RuntimeWarning):
+    """A runtime warning used by Molecule and its plugins."""
+
+
+class IncompatibleMoleculeRuntimeWarning(MoleculeRuntimeWarning):
+    """A warning noting an unsupported runtime environment."""
+
+
 @lru_cache()
 def drivers(config=None) -> UserListMap:
     """Return list of active drivers."""

--- a/src/molecule/test/unit/test_util.py
+++ b/src/molecule/test/unit/test_util.py
@@ -23,10 +23,12 @@ from __future__ import print_function
 import binascii
 import io
 import os
+import warnings
 
 import pytest
 
 from molecule import util
+from molecule.api import IncompatibleMoleculeRuntimeWarning, MoleculeRuntimeWarning
 from molecule.console import console
 from molecule.constants import MOLECULE_HEADER
 from molecule.test.conftest import get_molecule_file, molecule_directory
@@ -91,6 +93,21 @@ def test_sysexit_with_message(patched_logger_critical):
     assert 1 == e.value.code
 
     patched_logger_critical.assert_called_once_with("foo")
+
+
+def test_sysexit_with_warns(patched_logger_critical, patched_logger_warning):
+    with pytest.raises(SystemExit) as e:
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.filterwarnings("default", category=MoleculeRuntimeWarning)
+            warnings.warn("xxx", category=IncompatibleMoleculeRuntimeWarning)
+
+        util.sysexit_with_message("foo", warns=warns)
+
+    assert 1 == e.value.code
+
+    patched_logger_critical.assert_called_once_with("foo")
+    patched_logger_warning.assert_called_once_with("xxx")
 
 
 def test_sysexit_with_message_and_custom_code(patched_logger_critical):

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -30,7 +30,8 @@ import sys
 from dataclasses import dataclass
 from functools import lru_cache  # noqa
 from subprocess import CalledProcessError, CompletedProcess
-from typing import Any, Dict, List, MutableMapping, NoReturn, Optional, Union
+from typing import Any, Dict, Iterable, List, MutableMapping, NoReturn, Optional, Union
+from warnings import WarningMessage
 
 import jinja2
 import yaml
@@ -96,7 +97,10 @@ def sysexit(code: int = 1) -> NoReturn:
 
 
 def sysexit_with_message(
-    msg: str, code: int = 1, detail: Optional[MutableMapping] = None
+    msg: str,
+    code: int = 1,
+    detail: Optional[MutableMapping] = None,
+    warns: Iterable[WarningMessage] = (),
 ) -> None:
     """Exit with an error message."""
     # detail is usually a multi-line string which is not suitable for normal
@@ -108,6 +112,9 @@ def sysexit_with_message(
             detail_str = str(detail)
         print(detail_str)
     LOG.critical(msg)
+
+    for warn in warns:
+        LOG.warning(warn.__dict__["message"].args[0])
     sysexit(code)
 
 


### PR DESCRIPTION
Captures runtime warnings raise by driver.sanity_check() and
display them at the end in case of failure.

Related: https://github.com/ansible-community/molecule-podman/pull/76
