### PR TITLE
docs: add hint for verify playbook

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -84,7 +84,7 @@ directories:
   
 .. note::
 
-  Since the `verify.yml` playbook does not call your role, the `library` and `module_utils` 
+  If the `verify.yml` playbook does not explicitly `include_role` your role, the `library` and `module_utils` 
   provided by your role are not available in the playbook by default.
   If you need those for testing but would like to avoid re-running your role, consider adding 
   an empty task file `init.yml` to your role and use `tasks_from` to include your role in the `verify.yml` playbook::

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -81,27 +81,26 @@ directories:
 * ``verify.yml`` is the Ansible file used for testing as Ansible is the default :ref:`verifier`. This
   allows you to write specific tests against the state of the container after
   your role has finished executing. Other verifier tools are available (Note that :std:doc:`TestInfra <testinfra:index>` was the default verifier prior to molecule version 3).
-  
+
 .. note::
 
-    If the `verify.yml` playbook does not explicitly `include_role` your role, the `library` and `module_utils`
+    If the ``verify.yml`` playbook does not explicitly ``include_role`` your role, the ``library`` and ``module_utils``
     provided by your role are not available in the playbook by default.
     If you need those for testing but would like to avoid re-running your role, consider adding
-    an empty task file `init.yml` to your role and use `tasks_from` to include your role in the `verify.yml` playbook::
+    an empty task file ``init.yml`` to your role and use ``tasks_from`` to include your role in the ``verify.yml`` playbook:
 
     .. code-block:: yaml
 
         - name: Verify
           hosts: all
           become: true
-
           tasks:
-          - name: Initialize role library, ... without actually running the role
+          - name: Initialize role without actually running it
             include_role:
               name: my_role
               tasks_from: init
 
-          # Start testing: can now use role library
+          # Start testing: can use role library now
 
 
 .. _Jinja2: http://jinja.pocoo.org/

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -81,6 +81,27 @@ directories:
 * ``verify.yml`` is the Ansible file used for testing as Ansible is the default :ref:`verifier`. This
   allows you to write specific tests against the state of the container after
   your role has finished executing. Other verifier tools are available (Note that :std:doc:`TestInfra <testinfra:index>` was the default verifier prior to molecule version 3).
+  
+.. note::
+
+  Since the `verify.yml` playbook does not call your role, the `library` and `module_utils` 
+  provided by your role are not available in the playbook by default.
+  If you need those for testing but would like to avoid re-running your role, consider adding 
+  an empty task file `init.yml` to your role and use `tasks_from` to include your role in the `verify.yml` playbook::
+  
+  .. code-block:: yaml
+
+    - name: Verify
+      hosts: all
+      become: true
+
+      tasks:
+      - name: Initialize role library, ... without actually running the role
+        include_role:
+          name: my_role
+          tasks_from: init
+
+      # Start testing; can now use role library
 
 .. _Jinja2: http://jinja.pocoo.org/
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -84,24 +84,25 @@ directories:
   
 .. note::
 
-  If the `verify.yml` playbook does not explicitly `include_role` your role, the `library` and `module_utils` 
-  provided by your role are not available in the playbook by default.
-  If you need those for testing but would like to avoid re-running your role, consider adding 
-  an empty task file `init.yml` to your role and use `tasks_from` to include your role in the `verify.yml` playbook::
-  
-  .. code-block:: yaml
+    If the `verify.yml` playbook does not explicitly `include_role` your role, the `library` and `module_utils`
+    provided by your role are not available in the playbook by default.
+    If you need those for testing but would like to avoid re-running your role, consider adding
+    an empty task file `init.yml` to your role and use `tasks_from` to include your role in the `verify.yml` playbook::
 
-    - name: Verify
-      hosts: all
-      become: true
+    .. code-block:: yaml
 
-      tasks:
-      - name: Initialize role library, ... without actually running the role
-        include_role:
-          name: my_role
-          tasks_from: init
+        - name: Verify
+          hosts: all
+          become: true
 
-      # Start testing; can now use role library
+          tasks:
+          - name: Initialize role library, ... without actually running the role
+            include_role:
+              name: my_role
+              tasks_from: init
+
+          # Start testing: can now use role library
+
 
 .. _Jinja2: http://jinja.pocoo.org/
 


### PR DESCRIPTION
As discussed in https://github.com/ansible-community/molecule/issues/3045, if the `verify.yml` playbook does not run the tested role, the `library` and `module_utils` provided by the tested role are not available there [1].

Usually, one does not want to re-run the role in the `verify.yml` playbook since it was already run twice before during the converge and idempotence stages, but testing the configuration of the server may well involve some of the modules provided by the role.
One workaround [suggested by @tadeboro](https://github.com/ansible-community/molecule/issues/3045#issuecomment-835571183) is to add an empty task list to the role and then to restrict tasks of the role to this file when including it in the `verify.yml` playbook.
This PR adds a note regarding this to the docs.

[1]  The `library` actually *is* currently available, but [this is an oversight](https://github.com/ansible-community/molecule/issues/3045#issuecomment-835518824); the `module_utils` are not available.

#### PR Type

- Docs Pull Request
