### PR TITLE
Restore option to disable galaxy dependency check

### DIFF
--- a/src/molecule/dependency/ansible_galaxy/base.py
+++ b/src/molecule/dependency/ansible_galaxy/base.py
@@ -113,11 +113,11 @@ class AnsibleGalaxyBase(base.Base):
         )
 
     def execute(self):
-        super().execute()
         if not self.enabled:
             msg = "Skipping, dependency is disabled."
             LOG.warning(msg)
             return
+        super().execute()
 
         if not self._has_requirements_file():
             msg = "Skipping, missing the requirements file."


### PR DESCRIPTION
PR #3235 was incomplete and fixed the issue only for shell dependency
checker. This PR fixes also for Galaxy dependency checker.

Fixes: #3234