### PR TITLE
Ensure subprocesses are run via Runtime()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,6 @@ repos:
           - packaging
           - rich
           - ruamel.yaml>=0.17.10
-          - subprocess-tee>=0.2.0
           - types-PyYAML
           - types-dataclasses
           - types-filelock
@@ -82,7 +81,7 @@ repos:
     hooks:
       - id: pylint
         additional_dependencies:
-          - ansible-compat
+          - ansible-compat>=1.0.0
           - cerberus
           - click
           - click-help-colors
@@ -90,7 +89,6 @@ repos:
           - enrich>=1.2.7
           - filelock
           - pexpect
-          - subprocess-tee>=0.2.0
           - testinfra
   - repo: https://github.com/jazzband/pip-tools
     rev: 6.4.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -33,6 +33,3 @@ ignore_missing_imports = True
 
 [mypy-testinfra.*]
 ignore_missing_imports = True
-
-[mypy-subprocess_tee]
-ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,6 @@ install_requires =
     pluggy >= 0.7.1, < 2.0
     PyYAML >= 5.1
     rich >= 9.5.1
-    subprocess-tee >= 0.3.5
 
 [options.extras_require]
 # ansible extra is deprecated, will be removed in next version

--- a/src/molecule/app.py
+++ b/src/molecule/app.py
@@ -1,0 +1,13 @@
+"""Molecule Application Module."""
+from ansible_compat.runtime import Runtime
+
+
+class App:
+    """App class that keep runtime status."""
+
+    def __init__(self) -> None:
+        """Create a new app instance."""
+        self.runtime = Runtime(isolated=True)
+
+
+app = App()

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -21,11 +21,11 @@
 
 import logging
 import os
-from subprocess import run
 
 import click
 
 from molecule import scenarios, util
+from molecule.app import app
 from molecule.command import base
 
 LOG = logging.getLogger(__name__)
@@ -143,7 +143,7 @@ class Login(base.Base):
         login_cmd = self._config.driver.login_cmd_template.format(**login_options)
 
         cmd = f"/usr/bin/env {login_cmd}"
-        run(cmd, shell=True)
+        app.runtime.exec(cmd)
 
 
 @base.click_command_ex()

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -27,10 +27,10 @@ from typing import MutableMapping
 from uuid import uuid4
 
 from ansible_compat.ports import cache, cached_property
-from ansible_compat.runtime import Runtime
 from packaging.version import Version
 
 from molecule import api, interpolation, platforms, scenario, state, util
+from molecule.app import app
 from molecule.dependency import ansible_galaxy, shell
 from molecule.model import schema_v3
 from molecule.provisioner import ansible
@@ -52,7 +52,7 @@ def ansible_version() -> Version:
         "molecule.config.ansible_version is deprecated, will be removed in the future.",
         category=DeprecationWarning,
     )
-    return Runtime().version
+    return app.runtime.version
 
 
 # https://stackoverflow.com/questions/16017397/injecting-function-call-after-init-with-decorator  # noqa
@@ -106,7 +106,7 @@ class Config(object, metaclass=NewInitCaller):
         self._action = None
         self._run_uuid = str(uuid4())
         self.project_directory = os.getenv("MOLECULE_PROJECT_DIRECTORY", os.getcwd())
-        self.runtime = Runtime(isolated=True)
+        self.runtime = app.runtime
 
     def after_init(self):
         self.config = self._reget_config()

--- a/src/molecule/shell.py
+++ b/src/molecule/shell.py
@@ -24,11 +24,11 @@ import sys
 
 import click
 import packaging
-from ansible_compat.runtime import Runtime
 
 import molecule
 from molecule import command, logger
 from molecule.api import drivers
+from molecule.app import app
 from molecule.command.base import click_group_ex
 from molecule.config import MOLECULE_DEBUG, MOLECULE_VERBOSITY
 from molecule.console import console
@@ -60,8 +60,7 @@ def print_version(ctx, param, value):
     color = "bright_yellow" if v.is_prerelease else "green"
     msg = f"molecule [{color}]{v}[/] using python [repr.number]{sys.version_info[0]}.{sys.version_info[1]}[/] \n"
 
-    runtime = Runtime()
-    msg += f"    [repr.attrib_name]ansible[/][dim]:[/][repr.number]{runtime.version}[/]"
+    msg += f"    [repr.attrib_name]ansible[/][dim]:[/][repr.number]{app.runtime.version}[/]"
     for driver in drivers():
         msg += f"\n    [repr.attrib_name]{str(driver)}[/][dim]:[/][repr.number]{driver.version}[/][dim] from {driver.module}[/]"
         if driver.required_collections:

--- a/src/molecule/test/functional/conftest.py
+++ b/src/molecule/test/functional/conftest.py
@@ -28,11 +28,11 @@ from typing import Optional
 import pexpect
 import pytest
 from ansible_compat.ports import cache
-from ansible_compat.runtime import Runtime
 from packaging.version import Version
 
 import molecule
 from molecule import logger, util
+from molecule.app import app
 from molecule.test.conftest import change_dir_to, molecule_directory
 from molecule.text import strip_ansi_color
 from molecule.util import run_command
@@ -257,5 +257,4 @@ def supports_docker() -> bool:
 
 def min_ansible(version: str) -> bool:
     """Ensure current Ansible is newer than a given a minimal one."""
-    runtime = Runtime()
-    return bool(runtime.version >= Version(version))
+    return bool(app.runtime.version >= Version(version))

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -36,8 +36,8 @@ import jinja2
 import yaml
 from ansible_compat.ports import cache
 from rich.syntax import Syntax
-from subprocess_tee import run
 
+from molecule.app import app
 from molecule.console import console
 from molecule.constants import MOLECULE_HEADER
 
@@ -130,8 +130,6 @@ def run_command(
     :param debug: An optional bool to toggle debug output.
     """
     args = []
-    stdout = None
-    stderr = None
     if cmd.__class__.__name__ == "Command":
         raise RuntimeError(
             "Molecule 3.2.0 dropped use of sh library, update plugin code to use new API. "
@@ -143,23 +141,17 @@ def run_command(
         else:
             env = cmd.env or env
         args = cmd.cmd
-        cwd = cmd.cwd
-        stdout = cmd.stdout
-        stderr = cmd.stderr
     else:
         args = cmd
 
     if debug:
         print_environment_vars(env)
 
-    result = run(
-        args,
+    result = app.runtime.exec(
+        args=args,
         env=env,
-        stdout=stdout,
-        stderr=stderr,
-        echo=echo or debug,
-        quiet=quiet,
         cwd=cwd,
+        tee=True,
     )
     if result.returncode != 0 and check:
         raise CalledProcessError(


### PR DESCRIPTION
Instead of directly calling subprocess, ensure we use Runtime
api methods for running various commands, most importantly
ansible commands.

This also removes subprocess-tee dependency as a desired action.