### PR TITLE
Allows to take a newer pluggy release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ install_requires =
     Jinja2 >= 2.11.3
     packaging
     paramiko >= 2.5.0, < 3
-    pluggy >= 0.7.1, < 1.0
+    pluggy >= 0.7.1, <= 1.0
     PyYAML >= 5.1, < 6
     rich >= 9.5.1
     subprocess-tee >= 0.3.2


### PR DESCRIPTION
The pluggy module was added back in 2019 - there are newer releases now,
and we can expect other projects to depend on the 1.0 one - it would
then conflict with molecule, preventing developers to run smoothly there
unit tests.