### PR TITLE
Raise upper constraint for importlib-metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ install_requires =
     cookiecutter >= 1.7.3  # dependency issues in older versions
     dataclasses; python_version<"3.7"
     enrich >= 1.2.5
-    importlib-metadata<2; python_version<"3.8"
+    importlib-metadata; python_version<"3.8"
     Jinja2 >= 2.11.3
     packaging
     paramiko >= 2.5.0, < 3

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     devel: git+https://github.com/ansible-community/pytest-molecule#egg=pytest-molecule
     dockerfile: ansible>=2.10
     selinux
-    py{36,37}: importlib-metadata<2,>=0.12
+    py{36,37}: importlib-metadata>=0.12
     py: ansible-base
 extras =
     docker


### PR DESCRIPTION
The current version of importlib-metadata is 4.8.1 which works fine even
when running python <3.8.  By restricting to <2, we're limiting the
co-installability of molecule with projects that require higher
importlib-metadata. 

The <2 limit was added as part of #3221, but it's not clear why this version
was selected.

#### PR Type

- Bugfix Pull Request
