### PR TITLE
Restore auto-installation of local collection

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,22 +27,22 @@ jobs:
           - tox_env: docs
             python-version: 3.9
           - tox_env: py36
-            PREFIX: PYTEST_REQPASS=449
+            PREFIX: PYTEST_REQPASS=450
             python-version: 3.6
           - tox_env: py37
-            PREFIX: PYTEST_REQPASS=449
+            PREFIX: PYTEST_REQPASS=450
             python-version: 3.7
           - tox_env: py38
-            PREFIX: PYTEST_REQPASS=449
+            PREFIX: PYTEST_REQPASS=450
             python-version: 3.8
           - tox_env: py39
-            PREFIX: PYTEST_REQPASS=449
+            PREFIX: PYTEST_REQPASS=450
             python-version: 3.9
           - tox_env: py36-devel
-            PREFIX: PYTEST_REQPASS=449
+            PREFIX: PYTEST_REQPASS=450
             python-version: 3.6
           - tox_env: py39-devel
-            PREFIX: PYTEST_REQPASS=449
+            PREFIX: PYTEST_REQPASS=450
             python-version: 3.9
           - tox_env: packaging
             python-version: 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ install_requires =
     cookiecutter >= 1.7.3  # dependency issues in older versions
     dataclasses; python_version<"3.7"
     enrich >= 1.2.5
-    importlib-metadata<2; python_version<"3.8"
+    importlib-metadata; python_version<"3.8"
     Jinja2 >= 2.11.3
     packaging
     paramiko >= 2.5.0, < 3

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -109,6 +109,10 @@ def execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args=()
         if scenario.config.config["prerun"]:
             LOG.info("Performing prerun...")
             scenario.config.runtime.prepare_environment()
+            # if we are inside a collection we should also install it
+            if os.path.exists("galaxy.yml"):
+                LOG.info("Installing local collection...")
+                scenario.config.runtime.install_collection(".")
 
         if command_args.get("subcommand") == "reset":
             LOG.info("Removing %s" % scenario.ephemeral_directory)

--- a/src/molecule/test/functional/test_command.py
+++ b/src/molecule/test/functional/test_command.py
@@ -283,3 +283,12 @@ def test_command_test(scenario_to_test, with_scenario, scenario_name, driver_nam
 )
 def test_command_verify(scenario_to_test, with_scenario, scenario_name):
     verify(scenario_name)
+
+
+def test_sample_collection():
+    assert (
+        run_command(
+            ["molecule", "test"], cwd="src/molecule/test/resources/sample-collection"
+        ).returncode
+        == 0
+    )

--- a/src/molecule/test/resources/sample-collection/galaxy.yml
+++ b/src/molecule/test/resources/sample-collection/galaxy.yml
@@ -1,0 +1,31 @@
+name: bar
+namespace: foo
+version: 1.0.0
+readme: README.md
+authors:
+  - Red Hat
+description: Sample collection to use with molecule
+build_ignore:
+  - "*.egg-info"
+  - .DS_Store
+  - .eggs
+  - .gitignore
+  - .mypy_cache
+  - .pytest_cache
+  - .stestr
+  - .stestr.conf
+  - .tox
+  - .vscode
+  - MANIFEST.in
+  - build
+  - dist
+  - doc
+  - report.html
+  - setup.cfg
+  - setup.py
+  - "tests/unit/*.*"
+  - README.rst
+  - tox.ini
+
+repository: https://opendev.org/openstack/tripleo-repos
+license_file: LICENSE

--- a/src/molecule/test/resources/sample-collection/molecule/default/converge.yml
+++ b/src/molecule/test/resources/sample-collection/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: localhost
+  tasks:
+    - name: "Include sample role from current collection"
+      include_role:
+        name: foo.bar.baz

--- a/src/molecule/test/resources/sample-collection/molecule/default/molecule.yml
+++ b/src/molecule/test/resources/sample-collection/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/src/molecule/test/resources/sample-collection/roles/baz/tasks/main.yml
+++ b/src/molecule/test/resources/sample-collection/roles/baz/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: "some task inside foo.bar collection"
+  debug:
+    msg: "hello world!"

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     devel: git+https://github.com/ansible-community/pytest-molecule#egg=pytest-molecule
     dockerfile: ansible>=2.10
     selinux
-    py{36,37}: importlib-metadata<2,>=0.12
+    py{36,37}: importlib-metadata>=0.12
     py: ansible-base
 extras =
     docker


### PR DESCRIPTION
Before 3.4.0 molecule used to auto-install local collection if
one is detected. This patch restores this behavior and installs
a collection as part of the prerun.- Restore auto-installation of local collection
- Raise upper constraint for importlib-metadata (#3244)
