### PR TITLE
Add a Patchback config

### DIFF
--- a/.github/patchback.yml
+++ b/.github/patchback.yml
@@ -1,0 +1,5 @@
+---
+backport_branch_prefix: patchback/backports/
+backport_label_prefix: backport-
+target_branch_prefix: stable/
+...


### PR DESCRIPTION
This patch adds a configuration file for the Patchback GitHub App.

Once integrated and the labels exist, the bot will attempt to create backport PRs for the PR merges that are marked accordingly.

Ref: https://github.com/apps/patchback

#### PR Type

- Maintenance Pull Request