### PR TITLE
Add support for py310

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,12 +38,15 @@ jobs:
           - tox_env: py39
             PREFIX: PYTEST_REQPASS=449
             python-version: 3.9
+          - tox_env: py310
+            PREFIX: PYTEST_REQPASS=449
+            python-version: "3.10"
           - tox_env: py38-devel
             PREFIX: PYTEST_REQPASS=449
             python-version: 3.8
-          - tox_env: py39-devel
+          - tox_env: py310-devel
             PREFIX: PYTEST_REQPASS=449
-            python-version: 3.9
+            python-version: "3.10"
           - tox_env: packaging
             python-version: 3.9
           - tox_env: eco

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
     Topic :: System :: Systems Administration
     Topic :: Utilities

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ envlist =
     packaging
     dockerfile
     # keep only N,N-1 ansible versions
-    py{36,37,38,39}
-    py{38,39}-{devel}
+    py{36,37,38,39,310}
+    py{38,39,310}-{devel}
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False


### PR DESCRIPTION
Includes changes required for py310 compatibility:
* dropping of [unmaintained pytest-verbose-parametrize test dependency](https://github.com/man-group/pytest-plugins/issues/157)
* bumping subprocess-tee to a version supporting py310
* updating GHA pipelines to include py310

Related: https://github.com/ansible-community/devtools/issues/6
