### PR TITLE
fix: Remove pytest-verbose-parametrize test dependency

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -50,7 +50,6 @@ pytest-metadata==1.11.0
 pytest-mock==3.6.1
 pytest-plus==0.2
 pytest-testinfra==6.4.0
-pytest-verbose-parametrize==1.7.0
 pytest-xdist==2.3.0
 python-dateutil==2.8.2
 python-slugify==5.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -116,7 +116,6 @@ test =
     pytest-mock >= 3.3.1
     pytest-plus >= 0.2
     pytest-testinfra >= 6.1.0
-    pytest-verbose-parametrize >= 1.7.0
     pytest-xdist >= 2.1.0
     pytest >= 6.1.2
 lint =


### PR DESCRIPTION
We don't really need that dependency and its maintenance status
is far from good. That removal was needed for py310 compatibility.

Related: https://github.com/man-group/pytest-plugins/issues/157
