### PR TITLE
[util] prevent run_command stdout from using rich

### DIFF
--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -38,13 +38,13 @@ from ansible_compat.ports import cache
 from rich.syntax import Syntax
 from subprocess_tee import run
 
+from molecule.constants import MOLECULE_HEADER
+
 # This must be BEFORE molecule.console is imported below.
 SYS_STDOUT = sys.stdout
-from molecule.console import console
+from molecule.console import console  # pylint: disable=wrong-import-position
 
 CONSOLE_STDOUT = sys.stdout
-
-from molecule.constants import MOLECULE_HEADER
 
 LOG = logging.getLogger(__name__)
 

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -38,7 +38,12 @@ from ansible_compat.ports import cache
 from rich.syntax import Syntax
 from subprocess_tee import run
 
+# This must be BEFORE molecule.console is imported below.
+SYS_STDOUT = sys.stdout
 from molecule.console import console
+
+CONSOLE_STDOUT = sys.stdout
+
 from molecule.constants import MOLECULE_HEADER
 
 LOG = logging.getLogger(__name__)
@@ -151,6 +156,7 @@ def run_command(
     if debug:
         print_environment_vars(env)
 
+    sys.stdout = SYS_STDOUT
     result = run(
         args,
         env=env,
@@ -160,6 +166,8 @@ def run_command(
         quiet=quiet,
         cwd=cwd,
     )
+    sys.stdout = CONSOLE_STDOUT
+
     if result.returncode != 0 and check:
         raise CalledProcessError(
             returncode=result.returncode,

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -42,7 +42,8 @@ from molecule.constants import MOLECULE_HEADER
 
 # This must be BEFORE molecule.console is imported below.
 SYS_STDOUT = sys.stdout
-from molecule.console import console  # pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position
+from molecule.console import console  # noqa: E402
 
 CONSOLE_STDOUT = sys.stdout
 


### PR DESCRIPTION
Change:
- When importing molecule.console, we indirectly import 'enrich'.
  The 'enrich' library (at least, how we use it) will overwrite
  Python's sys.stdout and sys.stderr with a FileProxy from 'rich'.

  This causes problems when handling data with arbitrary escape codes
  that are used for various purposes such as ansible-runner's
  'awx_display' callback plugin, which hides base64 data with escape
  sequences, because 'rich' will drop any escape codes that are unknown
  to it.

  In order to be able to call into molecule's CLI via ansible-runner
  and not get a bunch of base64-encoded data mixed in the response, we
  need those escape codes to not be dropped. To work around this, we
  save a copy of sys.stdout before importing molecule.console, and
  swap sys.stdout to the original value (and back later) in
  run_command before we actually run the command.

Test Plan:
- Lots and lots of local testing and debugging.

Signed-off-by: Rick Elrod <rick@elrod.me>

Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request
