### PR TITLE
Correct ansible version used by devel pipelines

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,9 +38,9 @@ jobs:
           - tox_env: py39
             PREFIX: PYTEST_REQPASS=449
             python-version: 3.9
-          - tox_env: py36-devel
+          - tox_env: py38-devel
             PREFIX: PYTEST_REQPASS=449
-            python-version: 3.6
+            python-version: 3.8
           - tox_env: py39-devel
             PREFIX: PYTEST_REQPASS=449
             python-version: 3.9

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     dockerfile
     # keep only N,N-1 ansible versions
     py{36,37,38,39}
-    py{36,37,38,39}-{devel}
+    py{38,39}-{devel}
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -45,13 +45,13 @@ setenv =
     PYTHONUNBUFFERED=1
     _EXTRAS=-l --cov=molecule --no-cov-on-fail --cov-report xml:{envlogdir}/coverage.xml --html={envlogdir}/reports.html --self-contained-html
 deps =
-    devel: ansible>=2.10.0a2,<2.11
+    devel: git+https://github.com/ansible/ansible#egg=ansible-core
     # pytest-molecule not used but we want to check that it does not conflict
     devel: git+https://github.com/ansible-community/pytest-molecule#egg=pytest-molecule
     dockerfile: ansible>=2.10
     selinux
     py{36,37}: importlib-metadata>=0.12
-    py: ansible-base
+    py: ansible-core
 extras =
     docker
     lint


### PR DESCRIPTION
- devel pipelines should use ansible devel branch
- replace py36-devel with py38-devel as ansible requires 3.8+ on devel branch
- ansible-base package should not be used for generic `py` target