### PR TITLE
Deprecate ansible[-base] extras

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -63,7 +63,7 @@ jobs:
           sudo apt-get remove -y ansible \
           && sudo apt-get update \
           && sudo apt-get install -y libvirt-dev python3-cryptography python3-jinja2 python3-yaml virtualenv \
-          && pip3 install --user ansible-base \
+          && pip3 install --user ansible-core \
           && echo "$HOME/.local/bin" >> $GITHUB_PATH
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
       - name: Validate that ansible works

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,5 +12,5 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - ansible-base
+        - ansible-core
         - docs

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,7 +48,7 @@ Pip
 
 .. warning::
 
-  The old `ansible` and `ansible-base` pip extras are now deprecated and will
+  The old ``ansible`` and ``ansible-base`` pip extras are now deprecated and will
   be removed in molecule 3.6.0. If you use them, please switch to explicit
   package mention to avoid problem with newer versions of molecule.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -40,13 +40,17 @@ Pip
 
   Ansible is not listed as a direct dependency of molecule package because
   we only call it as a command line tool. You may want to install it
-  using your distribution package installer. If you want to also install a
-  compatible  version of ansible, make use of provided ``ansible`` or
-  ``ansible-base`` extras:
+  using your distribution package installer.
 
   .. code-block:: bash
 
-      $ python3 -m pip install "molecule[ansible]"  # or molecule[ansible-base]
+      $ python3 -m pip install molecule ansible-core
+
+.. warning::
+
+  The old `ansible` and `ansible-base` pip extras are now deprecated and will
+  be removed in molecule 3.6.0. If you use them, please switch to explicit
+  package mention to avoid problem with newer versions of molecule.
 
 Keep in mind that on selinux supporting systems, if you install into a virtual
 environment, you may face :gh:`issue <ansible/ansible/issues/34340>` even

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,8 +82,10 @@ install_requires =
     selinux; sys_platform=="linux"
 
 [options.extras_require]
+# ansible extra is deprecated, will be removed in next version
 ansible =
     ansible >= 2.10
+# ansible-base extra is deprecated, will be removed in next version
 ansible-base =
     ansible-base >= 2.10
 docs =

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,6 @@ commands =
     'import pathlib; '\
     'docs_dir = pathlib.Path(r"{toxinidir}") / "docs/docstree/html"; index_file = docs_dir / "index.html"; print(f"\nDocumentation available under `file://\{index_file\}`\n\nTo serve docs, use `python3 -m http.server --directory \{docs_dir\} 0`\n")'
 extras =
-    ansible-base
     docs
 
 [testenv:docs-livereload]
@@ -205,7 +204,7 @@ deps =
     pipdeptree >= 2.0.0
 commands =
     pip check
-    # disabled fails safe because we now install ansible-base on purpose
+    # disabled fails safe because we now install ansible-core on purpose
     # as the preinstalled version of ansible from github, cannot be called
     # when a virtualenv is activated.
     # fail-safe: stop if ansible can be imported, it means it was dragged in


### PR DESCRIPTION
* removes documentation about installing ansible as pip extra
* deprecates ansible and ansible-base extras
* updates our testing to make use of ansible-core instead of old
  ansible-base, especially as we already have two major versions
  using ansible-core package name.