### PR TITLE
Add Vagrant configuration to mimic GitHub runners

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -44,6 +44,8 @@ jobs:
           - tox_env: py38-devel
             PREFIX: PYTEST_REQPASS=449
             python-version: 3.8
+          - tox_env: py39-devel
+            PREFIX: PYTEST_REQPASS=449
           - tox_env: py310-devel
             PREFIX: PYTEST_REQPASS=449
             python-version: "3.10"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,28 @@
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+Vagrant.configure("2") do |config|
+  config.vbguest.installer_options = { allow_kernel_upgrade: true }
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 7168
+    v.cpus = 2
+    v.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+    v.customize ["modifyvm", :id, "--uartmode1", "file", File::NULL]
+  end
+
+  config.vm.define "focal" do |focal|
+    focal.vm.box = "ubuntu/focal64"
+    focal.vm.hostname = "focal"
+    focal.vm.provision "shell", path: "./tools/vagrant-test-runner.sh"
+  end
+
+  config.vm.define "bullseye" do |bullseye|
+    bullseye.vm.box = "debian/bullseye64"
+    bullseye.vm.hostname = "bullseye"
+    bullseye.vm.provision "shell", path: "./tools/vagrant-test-runner.sh"
+  end
+
+  config.vm.define "fedora" do |fedora|
+    fedora.vm.box = "fedora/35-cloud-base"
+    fedora.vm.hostname = "fedora"
+    fedora.vm.provision "shell", path: "./tools/vagrant-test-runner.sh"
+  end
+end

--- a/tools/vagrant-test-runner.sh
+++ b/tools/vagrant-test-runner.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -eux
+
+if command -v apt 1>/dev/null; then
+  . /etc/os-release
+
+  apt-get update
+  apt-get -y upgrade
+
+  if lsb_release -i | grep -i 'ubuntu'; then
+    add-apt-repository ppa:deadsnakes/ppa
+    echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | \
+      tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+    curl -sSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | \
+      tee /etc/apt/trusted.gpg.d/podman.asc
+
+    apt-get update
+    apt-get -y upgrade
+    apt-get -y install podman python3-pip python3.8 python3.8-distutils \
+      python3.9 python3.9-distutils python3.10 python3.10-distutils
+  fi
+
+  if lsb_release -i | grep -i 'debian'; then
+    apt-get -y install ansible-galaxy build-essential git libbz2-dev \
+      libffi-dev libgdbm-dev libncurses5-dev libnss3-dev libreadline-dev \
+      libsqlite3-dev libssl-dev podman python3.9 python3-pip wget zlib1g-dev
+    wget --no-clobber "https://www.python.org/ftp/python/3.10.0/Python-3.10.0.tgz"
+    tar -xf Python-3.10.*.tgz
+    cd Python-3.10.*/ || exit 1
+    ./configure --enable-optimizations
+    make -j "$(nproc)"
+    make altinstall
+    cd .. || exit 1
+  fi
+fi
+
+if command -v dnf 1>/dev/null; then
+  dnf -y upgrade
+  dnf -y install --enablerepo=updates-testing python3.10
+  dnf -y install git podman python3-pip python3.10 python3.10-pip
+fi
+
+export PATH="/usr/local/bin:${HOME}/.local/bin:$PATH"
+pip3 install ansible tox
+
+echo "
+  vagrant ssh
+  export PATH=\"/usr/local/bin:\${HOME}/.local/bin:\$PATH\"
+  cd /vagrant
+  time PYTEST_REQPASS=449 tox -e py310-devel
+"


### PR DESCRIPTION
This PR:
- adds `tox_env: py39-devel` to the GitHub workflow
- adds Vagrant configuration to mimic GitHub runners for local testing
- is related to #3291 

#### PR Type

- Feature Pull Request
