### PR TITLE
Support PyYAML 6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ install_requires =
     packaging
     paramiko >= 2.5.0, < 3
     pluggy >= 0.7.1, < 2.0
-    PyYAML >= 5.1, < 6
+    PyYAML >= 5.1
     rich >= 9.5.1
     subprocess-tee >= 0.3.5
     # selinux python module is needed as least by ansible-docker/podman modules


### PR DESCRIPTION
PyYAML 6.0 released on 2021-10-14 (see <https://github.com/yaml/pyyaml/releases/tag/6.0>).

This PR remove the upper cap for PyYAML, so both 5.4.1 and 6.0 could be install.

Dirty hack applied to <https://github.com/alvistack/ansible-community-molecule/tree/alvistack/3.5.2> and so <https://build.opensuse.org/package/show/home:alvistack/ansible-community-molecule-3.5.2>, manually confirmed as functioning for CentOS 7 / Ubuntu 21.10.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>

#### PR Type

- Feature Pull Request
