### PR TITLE
Ensure cwd is passed to utils.run_command() in all cases

### DIFF
--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -143,6 +143,7 @@ def run_command(
         else:
             env = cmd.env or env
         args = cmd.cmd
+        cwd = cmd.cwd
         stdout = cmd.stdout
         stderr = cmd.stderr
     else:


### PR DESCRIPTION
When trying to access Ansible vars in testinfra tests, the following
function call would fail to get values coming from host/group vars:

    host.ansible('debug', 'msg={{ hostvars[inventory_hostname] }}')


This was due to: 1. testinfra being executed into the directory where
molecule was launched instead of the scenario directory ; 2. group_vars
being located in the scenario directory.

This fix set the cwd passed to subprocess_tee to the cwd set in
BakedCommand and fixes the issue.

I tested this change by directly changing molecule code in my project and
printing the output of the above line. It shows my group vars as expected.

Fixes #151