### PR TITLE
Replace pep517.build with build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -155,9 +155,9 @@ usedevelop = false
 # don't install molecule itself in this env
 skip_install = true
 deps =
-    check-manifest
+    check-manifest >= 0.47
     collective.checkdocs >= 0.2
-    pep517 >= 0.8.2
+    build >= 0.7.0
     pip >= 20.2.2
     toml >= 0.10.1
     twine >= 3.2.0  # pyup: ignore
@@ -165,10 +165,8 @@ setenv =
 commands =
     rm -rfv {toxinidir}/dist/
     python -m check_manifest
-    python -m pep517.build \
-      --source \
-      --binary \
-      --out-dir {toxinidir}/dist/ \
+    python -m build \
+      --outdir {toxinidir}/dist/ \
       {toxinidir}
     # metadata validation
     sh -c "python -m twine check {toxinidir}/dist/*"


### PR DESCRIPTION
`build` is not cappend on purpose. I prefer to get this job failing with newer version of build than not knowing that newer version broke it.