### PR TITLE
Remove sudo from default alpine image

### DIFF
--- a/src/molecule/data/Dockerfile.j2
+++ b/src/molecule/data/Dockerfile.j2
@@ -18,5 +18,5 @@ RUN if [ $(command -v apt-get) ]; then export DEBIAN_FRONTEND=noninteractive && 
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 sudo bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y /usr/bin/python /usr/bin/python2-config sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 sudo bash iproute2 && zypper clean -a; \
-    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 sudo bash ca-certificates; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python3 sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/tox.ini
+++ b/tox.ini
@@ -138,6 +138,7 @@ deps =
 [testenv:dockerfile]
 description = Tests validity of embedded Dockerfile template used by docker driver
 commands =
+    ansible-galaxy collection install community.docker
     ansible-playbook src/molecule/data/validate-dockerfile.yml
 deps =
     ansible-core


### PR DESCRIPTION
As alpine does not have a `sudo` package, we remove it from the
template. This also fixed the broken CI job.

We also switch to dense output as it makes it easier to debug the
output of dockerfile job.