### PR TITLE
Add missing filelock test dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,11 +78,18 @@ repos:
           - types-filelock
           - types-setuptools
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.11.1
+    rev: v2.12.1
     hooks:
       - id: pylint
         additional_dependencies:
+          - ansible-compat
+          - cerberus
+          - click
+          - click-help-colors
+          - cookiecutter
           - enrich>=1.2.5
+          - filelock
+          - pexpect
           - subprocess-tee>=0.2.0
           - testinfra
   - # keep at bottom as these are slower

--- a/.pylintrc
+++ b/.pylintrc
@@ -13,7 +13,6 @@ disable =
     duplicate-code,
     fixme,
     implicit-str-concat,
-    import-error,
     import-outside-toplevel,
     inconsistent-return-statements,
     invalid-name,

--- a/constraints.txt
+++ b/constraints.txt
@@ -25,6 +25,7 @@ cryptography==35.0.0
 distro==1.6.0
 enrich==1.2.6
 execnet==1.9.0
+filelock==3.4.0
 idna==3.3
 iniconfig==1.1.1
 jinja2==3.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,7 @@ test =
     # We want to assure test extra provides tools to test molecule and its
     # related tools/plugins but w/o ansible, which can be installed separated.
     ansi2html >= 1.6.0
+    filelock
 
     pexpect >= 4.8.0, < 5
     pytest-cov >= 2.10.1

--- a/src/molecule/test/conftest.py
+++ b/src/molecule/test/conftest.py
@@ -146,6 +146,7 @@ def block_on_serial_mark(request):
     # https://github.com/pytest-dev/pytest-xdist/issues/385
     os.makedirs(".tox", exist_ok=True)
     if request.node.get_closest_marker("serial"):
+        # pylint: disable=abstract-class-instantiated
         with FileLock(".tox/semaphore.lock"):
             yield
     else:

--- a/src/molecule/test/unit/test_util.py
+++ b/src/molecule/test/unit/test_util.py
@@ -285,6 +285,7 @@ def test_verbose_flag():
     options = {"verbose": True, "v": True}
 
     assert ["-v"] == util.verbose_flag(options)
+    # pylint: disable=use-implicit-booleaness-not-comparison
     assert {} == options
 
 
@@ -292,12 +293,14 @@ def test_verbose_flag_extra_verbose():
     options = {"verbose": True, "vvv": True}
 
     assert ["-vvv"] == util.verbose_flag(options)
+    # pylint: disable=use-implicit-booleaness-not-comparison
     assert {} == options
 
 
 def test_verbose_flag_preserves_verbose_option():
     options = {"verbose": True}
 
+    # pylint: disable=use-implicit-booleaness-not-comparison
     assert [] == util.verbose_flag(options)
     assert {"verbose": True} == options
 


### PR DESCRIPTION
- add missing filelock
- reduce pylint ignores, which will also prevent similar regression