### PR TITLE
fix docstring for Schema v3 Validation Module

### DIFF
--- a/src/molecule/model/schema_v3.py
+++ b/src/molecule/model/schema_v3.py
@@ -17,7 +17,7 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
-"""Schema v2 Validation Module."""
+"""Schema v3 Validation Module."""
 
 import collections
 import functools


### PR DESCRIPTION
This is a rather small fix. The doc string should probably say "v3" as the files called `schema_v3.py`

#### PR Type

- Docs Pull Request
