### PR TITLE
Made pip-compile output silent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,13 +97,13 @@ repos:
     hooks:
     - id: pip-compile
       name: pip-compile
-      entry: pip-compile --strip-extras --no-annotate --output-file=constraints.txt setup.cfg --extra test --extra yamllint
+      entry: pip-compile -q --strip-extras --no-annotate --output-file=constraints.txt setup.cfg --extra test --extra yamllint
       language: system
       files: ^(setup\.cfg|=constraints\.txt)$
       pass_filenames: false
     - id: pip-compile-upgrade
       name: pip-compile-upgrade
-      entry: pip-compile --strip-extras -q --upgrade --no-annotate --output-file=constraints.txt setup.cfg --extra test --extra yamllint
+      entry: pip-compile -q --strip-extras -q --upgrade --no-annotate --output-file=constraints.txt setup.cfg --extra test --extra yamllint
       language: system
       files: ^(setup\.cfg|=constraints\.txt)$
       pass_filenames: false

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ description = Runs all linting tasks
 basepython = python3.9
 commands =
     # to run a single linter you can do "pre-commit run flake8"
-    python -m pre_commit run {posargs:--all}
+    python -m pre_commit run {posargs:--all --show-diff-on-failure}
 deps =
     pre-commit>=2.15.0
     pip-tools>=6.4.0


### PR DESCRIPTION
Made pip-compile output silent while enabling --show-diff-on-failure which provides a much easier to read output.