### PR TITLE
Avoid os.makedirs errors with existing folders

### DIFF
--- a/src/molecule/dependency/ansible_galaxy/base.py
+++ b/src/molecule/dependency/ansible_galaxy/base.py
@@ -137,7 +137,7 @@ class AnsibleGalaxyBase(base.Base):
         :return: None
         """
         if not os.path.isdir(self.install_path):
-            os.makedirs(self.install_path)
+            os.makedirs(self.install_path, exist_ok=True)
 
     def _has_requirements_file(self):
         return os.path.isfile(self.requirements_file)

--- a/src/molecule/scenario.py
+++ b/src/molecule/scenario.py
@@ -271,7 +271,7 @@ class Scenario(object):
         :return: None
         """
         if not os.path.isdir(self.inventory_directory):
-            os.makedirs(self.inventory_directory)
+            os.makedirs(self.inventory_directory, exist_ok=True)
 
 
 def ephemeral_directory(path: Optional[str] = None) -> str:

--- a/src/molecule/test/unit/conftest.py
+++ b/src/molecule/test/unit/conftest.py
@@ -121,7 +121,7 @@ def molecule_directory_fixture(temp_dir):
 def molecule_scenario_directory_fixture(molecule_directory_fixture):
     path = molecule_scenario_directory()
     if not os.path.isdir(path):
-        os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
 
     return path
 
@@ -130,7 +130,7 @@ def molecule_scenario_directory_fixture(molecule_directory_fixture):
 def molecule_ephemeral_directory_fixture(molecule_scenario_directory_fixture):
     path = molecule_ephemeral_directory(str(uuid4()))
     if not os.path.isdir(path):
-        os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
     yield
     shutil.rmtree(str(Path(path).parent))
 

--- a/src/molecule/test/unit/test_util.py
+++ b/src/molecule/test/unit/test_util.py
@@ -186,7 +186,7 @@ def test_os_walk(temp_dir):
     for scenario in scenarios:
         scenario_directory = os.path.join(mol_dir, scenario)
         molecule_file = get_molecule_file(scenario_directory)
-        os.makedirs(scenario_directory)
+        os.makedirs(scenario_directory, exist_ok=True)
         util.write_file(molecule_file, "")
 
     result = [f for f in util.os_walk(mol_dir, "molecule.yml")]


### PR DESCRIPTION
Fixes problems observed on CI, likely related to confurrency.
