### PR TITLE
Delete PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-Please include details of what it is, how to use it, how it's been tested
-
-#### PR Type
-
-- Bugfix Pull Request
-- Docs Pull Request
-- Feature Pull Request


### PR DESCRIPTION
That file is more of a inconvenience as we already have labels that determine the PR type. Also this does not play well with `gh` cli as it will append the template to the commit message, so someone will need to remove the template from the pull-request.
