### PR TITLE
Remove selinux from being exposed as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ python-slugify==5.0.2
 pyyaml==6.0
 requests==2.27.1
 rich==11.0.0
-selinux==0.2.1 ; "linux" in sys_platform
+selinux==0.2.1
 six==1.16.0
 subprocess-tee==0.3.5
 text-unidecode==1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,11 +74,6 @@ install_requires =
     PyYAML >= 5.1
     rich >= 9.5.1
     subprocess-tee >= 0.3.5
-    # selinux python module is needed as least by ansible-docker/podman modules
-    # and allows us of isolated (default) virtualenvs. It does not avoid need
-    # to install the system selinux libraries but it will provide a clear
-    # message when user has to do that.
-    selinux; "linux" in sys_platform
 
 [options.extras_require]
 # ansible extra is deprecated, will be removed in next version

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,6 @@ deps =
     # pytest-molecule not used but we want to check that it does not conflict
     devel: git+https://github.com/ansible-community/pytest-molecule#egg=pytest-molecule
     dockerfile: ansible>=2.10
-    selinux
     py{36,37}: importlib-metadata>=0.12
     py: ansible-core
 ; commands_pre =
@@ -141,7 +140,6 @@ deps =
     ansible-core
     paramiko
     docker
-    selinux
 
 [testenv:packaging]
 description =


### PR DESCRIPTION
We remove selinux from being exposed as a dependency of molecule because molecule itself does not need it. It would be up to the user to ensure that its ansible setup is correct. We still mention few hints about selinux and virtualenvs on our installation docs.

This change will enabled us to avoid some blocking problems with
newer pip-compile where the output cannot be kept the same on linux and non-linux.

Related to AAP and upcoming ee support, as ansible runtime may be on a different host thus installing selinux would be of no use. If someone needs selinux bindings they should install them explicitly.