### PR TITLE
Refactor run_command tests

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,25 +27,25 @@ jobs:
           - tox_env: docs
             python-version: 3.9
           - tox_env: py36
-            PREFIX: PYTEST_REQPASS=450
+            PREFIX: PYTEST_REQPASS=448
             python-version: 3.6
           - tox_env: py37
-            PREFIX: PYTEST_REQPASS=450
+            PREFIX: PYTEST_REQPASS=448
             python-version: 3.7
           - tox_env: py38
-            PREFIX: PYTEST_REQPASS=450
+            PREFIX: PYTEST_REQPASS=448
             python-version: 3.8
           - tox_env: py39
-            PREFIX: PYTEST_REQPASS=450
+            PREFIX: PYTEST_REQPASS=448
             python-version: 3.9
           - tox_env: py310
-            PREFIX: PYTEST_REQPASS=450
+            PREFIX: PYTEST_REQPASS=448
             python-version: "3.10"
           - tox_env: py38-devel
-            PREFIX: PYTEST_REQPASS=450
+            PREFIX: PYTEST_REQPASS=448
             python-version: 3.8
           - tox_env: py310-devel
-            PREFIX: PYTEST_REQPASS=450
+            PREFIX: PYTEST_REQPASS=448
             python-version: "3.10"
             # see https://github.com/ansible-community/molecule/issues/3291
             experimental: true

--- a/src/molecule/test/unit/test_util.py
+++ b/src/molecule/test/unit/test_util.py
@@ -139,37 +139,19 @@ def test_run_command_with_debug(mocker, patched_print_debug):
     assert x == patched_print_debug.mock_calls
 
 
-def test_run_command_baked_env(mocker):
-    run_mock = mocker.patch.object(util, "run")
-    run_mock.return_value = mocker.Mock(returncode=0)
-    cmd = util.BakedCommand(cmd=["ls"], env=None)
+def test_run_command_baked_cmd_env():
+    cmd = util.BakedCommand(cmd=["printenv", "myvar"], env=dict(myvar="myvalue"))
+    result = util.run_command(cmd, env=dict(myvar2="value2"))
+    assert result.returncode == 0
 
-    util.run_command(cmd, env=dict(myvar="myrealvalue"))
+    cmd = util.BakedCommand(cmd=["printenv", "myvar2"], env=dict(myvar="myvalue"))
+    result = util.run_command(cmd, env=dict(myvar2="value2"))
+    assert result.returncode == 0
 
-    # call_args[1] contains kwargs
-    assert run_mock.call_args[1]["env"] == dict(myvar="myrealvalue")
-
-
-def test_run_command_baked_cmd_env(mocker):
-    run_mock = mocker.patch.object(util, "run")
-    run_mock.return_value = mocker.Mock(returncode=0)
-    cmd = util.BakedCommand(cmd=["ls"], env=dict(myvar="myvalue"))
-
-    util.run_command(cmd)
-
-    # call_args[1] contains kwargs
-    assert run_mock.call_args[1]["env"] == dict(myvar="myvalue")
-
-
-def test_run_command_baked_both_envs(mocker):
-    run_mock = mocker.patch.object(util, "run")
-    run_mock.return_value = mocker.Mock(returncode=0)
-    cmd = util.BakedCommand(cmd=["ls"], env=dict(myvar="myvalue"))
-
-    util.run_command(cmd, env=dict(myvar="myrealvalue"))
-
-    # call_args[1] contains kwargs
-    assert run_mock.call_args[1]["env"] == dict(myvar="myrealvalue")
+    # negative test
+    cmd = util.BakedCommand(cmd=["printenv", "myvar"], env={})
+    result = util.run_command(cmd)
+    assert result.returncode == 1
 
 
 def test_run_command_with_debug_handles_no_env(mocker, patched_print_debug):


### PR DESCRIPTION
Refactor run_commands tests to avoid mocking internals and effectively
test for the desired behavior. This is also preparing for upcoming
change of run_command.

Related: #1649
