### PR TITLE
Improve documentation of molecule init role

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -32,7 +32,7 @@ To generate a new role with Molecule, simply run:
 
 .. code-block:: bash
 
-    $ molecule init role my_new_role --driver-name docker
+    $ molecule init role acme.my_new_role --driver-name docker
 
 You should then see a ``my_new_role`` folder in your current directory.
 

--- a/src/molecule/command/init/role.py
+++ b/src/molecule/command/init/role.py
@@ -37,9 +37,9 @@ class Role(base.Base):
     """
     Init Role Command Class.
 
-    .. program:: molecule init role foo
+    .. program:: molecule init role acme.foo
 
-    .. option:: molecule init role foo
+    .. option:: molecule init role acme.foo
 
         Initialize a new role.
 


### PR DESCRIPTION
Current implementation knows to add the namespace from the command line to `meta/main.yml` but we had few places where we forgot to update the examples.

Fixes: #3381