### PR TITLE
Remove `ansible` and `ansible-base` extras

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,9 +48,9 @@ Pip
 
 .. warning::
 
-  The old ``ansible`` and ``ansible-base`` pip extras are now deprecated and will
-  be removed in molecule 3.6.0. If you use them, please switch to explicit
-  package mention to avoid problem with newer versions of molecule.
+  ``ansible`` and ``ansible-base`` pip **extras** were removed in molecule
+  ``4.0.0``. If you used them, please switch to explicit package mention to
+  avoid problem with newer versions of molecule.
 
 Keep in mind that on selinux supporting systems, if you install into a virtual
 environment, you may face :gh:`issue <ansible/ansible/issues/34340>` even

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,12 +71,6 @@ install_requires =
     rich >= 9.5.1
 
 [options.extras_require]
-# ansible extra is deprecated, will be removed in next version
-ansible =
-    ansible >= 2.10
-# ansible-base extra is deprecated, will be removed in next version
-ansible-base =
-    ansible-base >= 2.10
 docs =
     Sphinx >= 4.3.2, < 4.4.0  # https://github.com/sphinx-doc/sphinx/issues/10112
     simplejson >= 3.17.2


### PR DESCRIPTION
In 4.0.0 we officially remove the deprecated extras so users can manually install the blend of ansible they want.

Previous commit to main started v4 development and now we have a `stable/3.6` created for backporting purposes.

Fixes: #3285