### PR TITLE
Refactor coverage implementation

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -29,26 +29,33 @@ jobs:
           - tox_env: py36
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.6
+            cover: true
           - tox_env: py37
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.7
+            cover: true
           - tox_env: py38
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.8
+            cover: true
           - tox_env: py39
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.9
+            cover: true
           - tox_env: py310
             PREFIX: PYTEST_REQPASS=448
             python-version: "3.10"
+            cover: true
           - tox_env: py38-devel
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.8
+            cover: true
           - tox_env: py310-devel
             PREFIX: PYTEST_REQPASS=448
             python-version: "3.10"
             # see https://github.com/ansible-community/molecule/issues/3291
             experimental: true
+            cover: true
           - tox_env: packaging
             python-version: 3.9
           - tox_env: eco
@@ -80,14 +87,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install -U pip
+          python -m pip install -U pip 'coverage[toml]'
           pip install tox
       - name: Run tox -e ${{ matrix.tox_env }}
         run: |
           echo "${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}"
           ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}
         continue-on-error: ${{ matrix.experimental || false }}
-
+      - name: Combine coverage data
+        # produce a single .coverage file at repo root
+        run: coverage combine .tox/.coverage.*
+        if:  ${{ matrix.cover == true }}
+      - name: Upload coverage data
+        if:  ${{ matrix.cover == true }}
+        uses: codecov/codecov-action@v1
+        with:
+          name: ${{ matrix.tox_env }}
+          fail_ci_if_error: true  # optional (default = false)
+          verbose: true  # optional (default = false)
   check:
     if: always()
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  require_ci_to_pass: true
+comment: false
+coverage:
+  status:
+    patch: false
+    project:
+      threshold: 0.5%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,16 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:"
+]
+
 [tool.black]
 skip-string-normalization = false
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,6 @@ pygments==2.11.2
 pynacl==1.4.0
 pyparsing==3.0.6
 pytest==6.2.5
-pytest-cov==3.0.0
 pytest-forked==1.4.0
 pytest-html==3.1.1
 pytest-metadata==1.11.0
@@ -65,7 +64,6 @@ six==1.16.0
 subprocess-tee==0.3.5
 text-unidecode==1.3
 toml==0.10.2
-tomli==1.2.3
 typing-extensions==4.0.1
 urllib3==1.26.8
 zipp==3.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,10 +97,10 @@ test =
     # We want to assure test extra provides tools to test molecule and its
     # related tools/plugins but w/o ansible, which can be installed separated.
     ansi2html >= 1.6.0
+    coverage >= 6.2
     filelock
 
     pexpect >= 4.8.0, < 5
-    pytest-cov >= 2.10.1
     pytest-html >= 3.0.0
     pytest-mock >= 3.3.1
     pytest-plus >= 0.2

--- a/tox.ini
+++ b/tox.ini
@@ -40,13 +40,14 @@ setenv =
     ANSIBLE_DISPLAY_FAILED_STDERR=1
     ANSIBLE_NOCOWS=1
     ANSIBLE_VERBOSITY=1
+    COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     MOLECULE_NO_LOG=0
     PIP_CONSTRAINT = {toxinidir}/requirements.txt
     devel: PIP_CONSTRAINT=/dev/null
     PIP_DISABLE_PIP_VERSION_CHECK=1
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1
-    _EXTRAS=-l -n auto --cov=molecule --no-cov-on-fail --cov-report xml:{envlogdir}/coverage.xml --html={envlogdir}/reports.html --self-contained-html
+    _EXTRAS=-l -n auto --html={envlogdir}/reports.html --self-contained-html
 deps =
     --editable .[docker,lint,podman,test,windows]
     devel: git+https://github.com/ansible/ansible#egg=ansible-core
@@ -66,7 +67,7 @@ commands =
     # failsafe for preventing changes that may break pytest collection
     sh -c "PYTEST_ADDOPTS= python -m pytest -p no:cov --collect-only"
     # html report is used by Zuul CI to display reports
-    python -m pytest {env:_EXTRAS} {env:PYTEST_ADDOPTS:} {posargs}
+    coverage run -m pytest {env:_EXTRAS} {env:PYTEST_ADDOPTS:} {posargs}
 
 allowlist_externals =
     find


### PR DESCRIPTION
Adopts the same coverage configuration we use on ansible-compat, which includes:

- avoid using pytest-cov
- integration with codecov.io
- avoid noisy messages from codecov on pull requests, as   we have a GHA check to report its status

Related: https://github.com/ansible-community/ansible-lint/pull/1810