### PR TITLE
docs: molecule doesn't support interactive passwd

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -142,3 +142,12 @@ approach like this in your role's ``meta/main.yml``:
   dependencies:
     - role: <your-dependee-role>
       when: lookup('env', 'MOLECULE_FILE')
+
+Can I use ASK_VAULT_PASS with molecule?
+=======================================
+
+No, molecule does not support interactive password prompts. If you need to
+unlock a vault, you must supply the password non-interactively (e.g., via
+a password file.) 
+
+See: https://github.com/ansible-community/molecule/issues/478


### PR DESCRIPTION
I just recently started using ansible, ansible-vault, and molecule. Today I created my first vault, and added `ask_vault_pass = True` to my ansible.cfg. I spent a little too long trying to figure out what I did wrong- but it turns out this feature simply isn't supported by molecule (and doesn't seem to be documented outside of the issue tracker.)

Hopefully this short note will help future newbies 😄 