### PR TITLE
Enable codecov.io integration

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -29,26 +29,33 @@ jobs:
           - tox_env: py36
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.6
+            cover: true
           - tox_env: py37
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.7
+            cover: true
           - tox_env: py38
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.8
+            cover: true
           - tox_env: py39
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.9
+            cover: true
           - tox_env: py310
             PREFIX: PYTEST_REQPASS=448
             python-version: "3.10"
+            cover: true
           - tox_env: py38-devel
             PREFIX: PYTEST_REQPASS=448
             python-version: 3.8
+            cover: true
           - tox_env: py310-devel
             PREFIX: PYTEST_REQPASS=448
             python-version: "3.10"
             # see https://github.com/ansible-community/molecule/issues/3291
             experimental: true
+            cover: true
           - tox_env: packaging
             python-version: 3.9
           - tox_env: eco
@@ -80,14 +87,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install -U pip
+          python -m pip install -U pip 'coverage[toml]'
           pip install tox
       - name: Run tox -e ${{ matrix.tox_env }}
         run: |
           echo "${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}"
           ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}
         continue-on-error: ${{ matrix.experimental || false }}
-
+      - name: Combine coverage data
+        # produce a single .coverage file at repo root
+        run: coverage combine .tox/.coverage.*
+        if:  ${{ matrix.cover == true }}
+      - name: Upload coverage data
+        if:  ${{ matrix.cover == true }}
+        uses: codecov/codecov-action@v1
+        with:
+          name: ${{ matrix.tox_env }}
+          fail_ci_if_error: true  # optional (default = false)
+          verbose: true  # optional (default = false)
   check:
     if: always()
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  require_ci_to_pass: true
+comment: false
+coverage:
+  status:
+    patch: false
+    project:
+      threshold: 0.5%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,16 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:"
+]
+
 [tool.black]
 skip-string-normalization = false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,7 @@ test =
     # We want to assure test extra provides tools to test molecule and its
     # related tools/plugins but w/o ansible, which can be installed separated.
     ansi2html >= 1.6.0
+    coverage >= 6.2
     filelock
 
     pexpect >= 4.8.0, < 5

--- a/tox.ini
+++ b/tox.ini
@@ -40,13 +40,14 @@ setenv =
     ANSIBLE_DISPLAY_FAILED_STDERR=1
     ANSIBLE_NOCOWS=1
     ANSIBLE_VERBOSITY=1
+    COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     MOLECULE_NO_LOG=0
     PIP_CONSTRAINT = {toxinidir}/requirements.txt
     devel: PIP_CONSTRAINT=/dev/null
     PIP_DISABLE_PIP_VERSION_CHECK=1
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1
-    _EXTRAS=-l -n auto --cov=molecule --no-cov-on-fail --cov-report xml:{envlogdir}/coverage.xml --html={envlogdir}/reports.html --self-contained-html
+    _EXTRAS=-l -n auto --cov=molecule --no-cov-on-fail --html={envlogdir}/reports.html --self-contained-html
 deps =
     --editable .[docker,lint,podman,test,windows]
     devel: git+https://github.com/ansible/ansible#egg=ansible-core


### PR DESCRIPTION
Apparently pytest-cov does a [better job](https://app.codecov.io/gh/ansible-community/molecule/pulls?page=1&state=open&order=-pullid) measuring coverage than just coverage.py as it reports 93% instead of 43% via #3396

Closes: #3396