### PR TITLE
Add deprecation warning for the `mol` command

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ lint =
 [options.entry_points]
 console_scripts =
     molecule = molecule.__main__:main
-    mol = molecule.__main__:main
+    mol = molecule.__main__:mol_deprecation_notice
 molecule.driver =
     delegated = molecule.driver.delegated:Delegated
 molecule.verifier =

--- a/src/molecule/__main__.py
+++ b/src/molecule/__main__.py
@@ -20,6 +20,14 @@
 """Molecule CLI main entry point."""
 
 from molecule.shell import main
+import warnings
+
+def mol_deprecation_notice():
+    warnings.warn(
+        "The `mol` command is deprecated and will be removed in a future version of Molecule. If you wish to continue using it, please create an alias that calls `molecule`.",
+        category=UserWarning,
+    )
+    main()
 
 if __name__ == "__main__":
     main()

--- a/src/molecule/__main__.py
+++ b/src/molecule/__main__.py
@@ -19,8 +19,10 @@
 #  DEALINGS IN THE SOFTWARE.
 """Molecule CLI main entry point."""
 
-from molecule.shell import main
 import warnings
+
+from molecule.shell import main
+
 
 def mol_deprecation_notice():
     warnings.warn(
@@ -28,6 +30,7 @@ def mol_deprecation_notice():
         category=UserWarning,
     )
     main()
+
 
 if __name__ == "__main__":
     main()

--- a/src/molecule/__main__.py
+++ b/src/molecule/__main__.py
@@ -25,11 +25,15 @@ from molecule.shell import main
 
 
 def mol_deprecation_notice():
-    warnings.warn(
-        "The `mol` command is deprecated and will be removed in a future version of Molecule. If you wish to continue using it, please create an alias that calls `molecule`.",
-        category=UserWarning,
-    )
-    main()
+    """Display a deprecation notice about mol command."""
+    try:
+        main()
+    except BaseException:
+        warnings.warn(
+            "The `mol` command is deprecated and will be removed in a future version of Molecule. If you wish to continue using it, please create an alias that calls `molecule`.",
+            category=UserWarning,
+        )
+        raise
 
 
 if __name__ == "__main__":

--- a/src/molecule/test/unit/test_api.py
+++ b/src/molecule/test/unit/test_api.py
@@ -49,5 +49,6 @@ def test_cli_mol():
     cmd_mol = ["mol", "--version"]
     y = util.run_command(cmd_mol)
     assert x.returncode == y.returncode
-    assert x.stderr == y.stderr
-    assert x.stdout == y.stdout
+    assert x.stderr in y.stderr
+    assert x.stdout in y.stdout
+    assert "UserWarning" in y.stdout


### PR DESCRIPTION
The `mol` command can be replaced with a shell alias for those users that need
it. Output a deprecation warning when the `mol` command is run that informs the
user that the command will be removed in a future release of Molecule.

Addresses issue #3406