### PR TITLE
Fix prepare_environment call for role installs

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -108,7 +108,7 @@ def execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args=()
 
         if scenario.config.config["prerun"]:
             LOG.info("Performing prerun...")
-            scenario.config.runtime.prepare_environment()
+            scenario.config.runtime.prepare_environment(install_local=True)
 
         if command_args.get("subcommand") == "reset":
             LOG.info("Removing %s", scenario.ephemeral_directory)

--- a/src/molecule/test/functional/test_command.py
+++ b/src/molecule/test/functional/test_command.py
@@ -18,6 +18,7 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import os
 from typing import Optional
 
 import pytest
@@ -106,9 +107,14 @@ def test_command_converge(scenario_to_test, with_scenario, scenario_name):
     indirect=["scenario_to_test", "driver_name", "scenario_name"],
 )
 @pytest.mark.serial
-def test_command_create(scenario_to_test, with_scenario, scenario_name):
+def test_command_create(scenario_to_test, with_scenario, scenario_name, tmp_path):
+    os.environ["ANSIBLE_ROLES_PATH"] = str(tmp_path)
     cmd = ["molecule", "create", "--scenario-name", scenario_name]
-    assert run_command(cmd).returncode == 0
+    assert run_command(cmd, env=os.environ).returncode == 0
+
+    # Validate that ansible-compat created a symlink in the roles path
+    role_path = tmp_path / "molecule.delegated_test"
+    assert role_path.is_symlink()
 
 
 @pytest.mark.parametrize(

--- a/src/molecule/test/scenarios/driver/delegated/meta/main.yml
+++ b/src/molecule/test/scenarios/driver/delegated/meta/main.yml
@@ -1,0 +1,8 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: Molecule Developer
+  description: Role to test ansible_compat installation of role
+  namespace: molecule
+  role_name: delegated_test


### PR DESCRIPTION
Fixes local role installations with `ansible-compat` version 1.0.0 as discussed in issue #3404.