### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -136,6 +136,12 @@ some benefits:
     .. _test.pypi.org/project/molecule: https://test.pypi.org/project/molecule/
     .. _release history: https://test.pypi.org/project/molecule/#history
 
+Install ``community.docker`` collection:
+
+.. code-block:: bash
+
+    $ ansible-galaxy collection install community.docker
+
 Docker
 ======
 


### PR DESCRIPTION
It is not clear that `community.docker` should be installed. The error message shows this, however, I think, it is worth mentioning in the installation guide this step.