### PR TITLE
Add support for MOLECULE_PLATFORM_NAME

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,23 +27,23 @@ jobs:
           - tox_env: docs
             python-version: 3.9
           - tox_env: py38
-            PREFIX: PYTEST_REQPASS=447
+            PREFIX: PYTEST_REQPASS=450
             python-version: 3.8
             cover: true
           - tox_env: py39
-            PREFIX: PYTEST_REQPASS=447
+            PREFIX: PYTEST_REQPASS=450
             python-version: 3.9
             cover: true
           - tox_env: py310
-            PREFIX: PYTEST_REQPASS=447
+            PREFIX: PYTEST_REQPASS=450
             python-version: "3.10"
             cover: true
           - tox_env: py38-devel
-            PREFIX: PYTEST_REQPASS=447
+            PREFIX: PYTEST_REQPASS=450
             python-version: 3.8
             cover: true
           - tox_env: py310-devel
-            PREFIX: PYTEST_REQPASS=447
+            PREFIX: PYTEST_REQPASS=450
             python-version: "3.10"
             # see https://github.com/ansible-community/molecule/issues/3291
             experimental: true

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -217,3 +217,8 @@ The full lifecycle sequence can be invoked with:
     It can be particularly useful to pass the ``--destroy=never`` flag when
     invoking ``molecule test`` so that you can tell Molecule to run the full
     sequence but not destroy the instance if one step fails.
+
+    If the ``--platform-name=[PLATFORM_NAME]`` flag is passed or the
+    environment variable ``MOLECULE_PLATFORM_NAME`` is exposed when invoking
+    ``molecule test``, it can tell Molecule to run the test in one platform
+    only. It is useful if you want to test one platform docker image.

--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -31,6 +31,7 @@ from molecule.config import DEFAULT_DRIVER
 
 LOG = logging.getLogger(__name__)
 MOLECULE_PARALLEL = os.environ.get("MOLECULE_PARALLEL", False)
+MOLECULE_PLATFORM_NAME = os.environ.get("MOLECULE_PLATFORM_NAME", None)
 
 
 class Test(base.Base):
@@ -116,6 +117,12 @@ class Test(base.Base):
     help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
 @click.option(
+    "--platform-name",
+    "-p",
+    default=MOLECULE_PLATFORM_NAME,
+    help="Name of the platform to target only. Default is None",
+)
+@click.option(
     "--driver-name",
     "-d",
     type=click.Choice([str(s) for s in drivers()]),
@@ -140,7 +147,14 @@ class Test(base.Base):
 )
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
 def test(
-    ctx, scenario_name, driver_name, __all, destroy, parallel, ansible_args
+    ctx,
+    scenario_name,
+    driver_name,
+    __all,
+    destroy,
+    parallel,
+    ansible_args,
+    platform_name,
 ):  # pragma: no cover
     """Test (dependency, lint, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy)."""
     args = ctx.obj.get("args")
@@ -150,6 +164,7 @@ def test(
         "destroy": destroy,
         "subcommand": subcommand,
         "driver_name": driver_name,
+        "platform_name": platform_name,
     }
 
     if __all:

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -134,6 +134,10 @@ class Config(object, metaclass=NewInitCaller):
         return self.command_args.get("parallel", False)
 
     @property
+    def platform_name(self):
+        return self.command_args.get("platform_name", None)
+
+    @property
     def debug(self):
         return self.args.get("debug", MOLECULE_DEBUG)
 
@@ -206,7 +210,11 @@ class Config(object, metaclass=NewInitCaller):
 
     @cached_property
     def platforms(self):
-        return platforms.Platforms(self, parallelize_platforms=self.is_parallel)
+        return platforms.Platforms(
+            self,
+            parallelize_platforms=self.is_parallel,
+            platform_name=self.platform_name,
+        )
 
     @cached_property
     def provisioner(self):

--- a/src/molecule/platforms.py
+++ b/src/molecule/platforms.py
@@ -68,13 +68,19 @@ class Platforms(object):
               - child_group1
     """
 
-    def __init__(self, config, parallelize_platforms=False):
+    def __init__(self, config, parallelize_platforms=False, platform_name=None):
         """
         Initialize a new platform class and returns None.
 
         :param config: An instance of a Molecule config.
+        :param parallelize_platforms: Parallel mode. Default is False.
+        :param platform_name: One platform to target only, defaults to None.
         :return: None
         """
+        if platform_name:
+            config.config["platforms"] = util._filter_platforms(
+                config.config, platform_name
+            )
         if parallelize_platforms:
             config.config["platforms"] = util._parallelize_platforms(
                 config.config, config._run_uuid

--- a/src/molecule/test/unit/test_platforms.py
+++ b/src/molecule/test/unit/test_platforms.py
@@ -35,3 +35,26 @@ def test_instances_property(_instance):
     ]
 
     assert x == _instance.instances
+
+
+@pytest.fixture
+def platform_name(request, config_instance):
+    return platforms.Platforms(config_instance, platform_name=request.param)
+
+
+@pytest.mark.parametrize("platform_name", ["instance-1"], indirect=True)
+def test_instances_property_with_platform_name_instance_1(platform_name):
+    x = [
+        {"groups": ["foo", "bar"], "name": "instance-1", "children": ["child1"]},
+    ]
+
+    assert x == platform_name.instances
+
+
+@pytest.mark.parametrize("platform_name", ["instance-2"], indirect=True)
+def test_instances_property_with_platform_name_instance_2(platform_name):
+    x = [
+        {"groups": ["baz", "foo"], "name": "instance-2", "children": ["child2"]},
+    ]
+
+    assert x == platform_name.instances

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -336,6 +336,14 @@ def _parallelize_platforms(config, run_uuid):
     return [parallelize(platform) for platform in config["platforms"]]
 
 
+def _filter_platforms(config, platform_name):
+    for platform in config["platforms"]:
+        if platform["name"] == platform_name:
+            return [platform]
+
+    return []
+
+
 @cache
 def find_vcs_root(location="", dirs=(".git", ".hg", ".svn"), default=None) -> str:
     """Return current repository root directory."""


### PR DESCRIPTION
Fix #3415 

There are no environment variable `MOLECULE_PLATFORM_NAME` set by default.

How to use

1. Test one image

  Assume platform name is `ubuntu-18.04`
  ```bash
  molecule test --platform=ubuntu-18.04
  ```
  or
  ```bash
  export MOLECULE_PLATFORM_NAME=ubuntu-18.04
  molecule test
  ```

2. Test all images

  ```bash
  unset MOLECULE_PLATFORM_NAME
  molecule test
  ```
