### PR TITLE
Remove paramiko dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,9 @@ ansible-pygments==0.1.1
 arrow==1.2.2
 attrs==21.4.0
 babel==2.9.1
-bcrypt==3.2.0
 binaryornot==0.4.4
 cerberus==1.3.2
 certifi==2021.10.8
-cffi==1.15.0
 chardet==4.0.0
 charset-normalizer==2.0.12
 click==8.0.4
@@ -24,7 +22,6 @@ colorama==0.4.4
 commonmark==0.9.1
 cookiecutter==1.7.3
 coverage==6.3.2
-cryptography==36.0.1
 distro==1.7.0
 docutils==0.17.1
 enrich==1.2.7
@@ -38,15 +35,12 @@ jinja2-time==0.2.0
 markupsafe==2.1.0
 more-itertools==8.12.0
 packaging==21.3
-paramiko==2.9.2
 pexpect==4.8.0
 pluggy==1.0.0
 poyo==0.5.0
 ptyprocess==0.7.0
 py==1.11.0
-pycparser==2.21
 pygments==2.11.2
-pynacl==1.5.0
 pyparsing==3.0.7
 pytest==7.0.1
 pytest-cov==3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,6 @@ install_requires =
     enrich >= 1.2.7
     Jinja2 >= 2.11.3
     packaging
-    paramiko >= 2.5.0, < 3
     pluggy >= 0.7.1, < 2.0
     PyYAML >= 5.1
     rich >= 9.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -137,7 +137,6 @@ commands =
     ansible-playbook src/molecule/data/validate-dockerfile.yml
 deps =
     ansible-core
-    paramiko
     docker
 
 [testenv:packaging]


### PR DESCRIPTION
As paramiko is not used by molecule core we should not
list it as a dependency.
