### PR TITLE
Enable packit rpm building for Fedora 35

### DIFF
--- a/.config/molecule.spec
+++ b/.config/molecule.spec
@@ -1,0 +1,85 @@
+# spell-checker:ignore bcond pkgversion buildrequires autosetup PYTHONPATH noarch buildroot bindir sitelib numprocesses
+# All tests require Internet access
+# to test in mock use:  --enable-network --with check
+# to test in a privileged environment use:
+#   --with check --with privileged_tests
+%bcond_with     check
+%bcond_with     privileged_tests
+
+Name:           molecule
+Version:        VERSION_PLACEHOLDER
+Release:        1%{?dist}
+Summary:        Molecule testing framework for Ansible content
+
+License:        MIT
+URL:            https://github.com/ansible-community/molecule
+Source0:        %{pypi_source}
+
+BuildArch:      noarch
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python%{python3_pkgversion}-build
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-setuptools_scm
+BuildRequires:  python%{python3_pkgversion}-wheel
+%if %{with check}
+# These are required for tests:
+BuildRequires:  python%{python3_pkgversion}-pyyaml
+BuildRequires:  python%{python3_pkgversion}-pytest
+BuildRequires:  python%{python3_pkgversion}-pytest-xdist
+BuildRequires:  python%{python3_pkgversion}-libselinux
+BuildRequires:  git
+%endif
+# Named based on fedora 35:
+Requires:       ansible-core
+Requires:       python3-enrich
+Requires:       python3-packaging
+Requires:       python3-pyyaml
+Requires:       python3-rich
+
+# generate_buildrequires
+# pyproject_buildrequires
+
+%description
+Molecule provides support for testing with multiple instances, operating
+systems and distributions, virtualization providers, test frameworks and
+testing scenarios.
+
+%prep
+%autosetup
+
+
+%build
+%pyproject_wheel
+
+
+%install
+%pyproject_install
+
+
+%if %{with check}
+%check
+PYTHONPATH=%{buildroot}%{python3_sitelib} \
+  pytest-3 \
+  -v \
+  --disable-pytest-warnings \
+  --numprocesses=auto \
+%if %{with privileged_tests}
+  tests
+%else
+  tests/unit
+%endif
+%endif
+
+
+%files
+%{python3_sitelib}/molecule/
+%{python3_sitelib}/molecule-*.dist-info/
+%{_bindir}/molecule
+%license LICENSE
+%doc docs/* README.rst
+
+%changelog
+Available at https://github.com/ansible-community/molecule/releases

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,33 @@
+# spell-checker:ignore packit specfile copr epel
+specfile_path: dist/molecule.spec
+actions:
+  create-archive:
+    # packit.dev service does have these module pre-installed:
+    - python3 -m pip install --user build setuptools-scm
+    - python3 -m build --sdist --outdir dist
+    - sh -c "ls dist/molecule-*.tar.gz"
+  get-current-version:
+    - ./tools/get-version.sh
+  post-upstream-clone:
+    - ./tools/update-version.sh
+jobs:
+  - job: copr_build
+    metadata:
+      targets:
+        # Unable to build `centos-stream` due to missing python3-setuptools_scm_git_archive
+        # which is part of EPEL.
+        # - centos-stream-x86_64
+        # - epel-8-x86_64
+        # Unable to build fedora-stable as it includes both 34 and 35 and on first one we do not have python3-setuptools_scm
+        # - fedora-stable
+        - fedora-35
+    trigger: pull_request
+  # - job: tests
+  #   trigger: pull_request
+  #   metadata:
+  #     targets:
+  #     - fedora-all
+  # - job: propose_downstream
+  #   trigger: release
+  #   metadata:
+  #     dist-git-branch: master

--- a/tools/get-version.sh
+++ b/tools/get-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+{
+    python3 -c "import setuptools_scm" || python3 -m pip install --user setuptools-scm
+} 1>&2  # redirect stdout to stderr to avoid polluting the output
+python3 -m setuptools_scm | \
+    sed 's/Guessed Version\([^+]\+\).*/\1/'

--- a/tools/update-version.sh
+++ b/tools/update-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+DIR=$(dirname "$0")
+VERSION=$(./tools/get-version.sh)
+mkdir -p "${DIR}/../dist"
+sed -e "s/VERSION_PLACEHOLDER/${VERSION}/" \
+    "${DIR}/../.config/molecule.spec" \
+    > "${DIR}/../dist/molecule.spec"


### PR DESCRIPTION
The layout is based on the the one used by ansible-lint project.