### PR TITLE
Fix additional_files_or_dirs in skip check

### DIFF
--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -171,7 +171,7 @@ class Testinfra(Verifier):
             LOG.warning(msg)
             return
 
-        if not len(self._tests) > 0:
+        if not (len(self._tests) + len(self.additional_files_or_dirs)) > 0:
             msg = "Skipping, no tests found."
             LOG.warning(msg)
             return


### PR DESCRIPTION
Issue: When no tests are found in `self.directory` but actually there is test in `additional_files_or_dirs` the whole `Testinfra.execute()` is skipped.
This commit fix this corner case by skipping `Testinfra.execute()` only if there is no tests neither in `self.directory` nor in `additional_files_or_dirs`