### PR TITLE
fix broken molecule login

### DIFF
--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -21,6 +21,7 @@
 
 import logging
 import os
+import subprocess
 
 import click
 
@@ -142,8 +143,8 @@ class Login(base.Base):
         login_options["lines"] = lines
         login_cmd = self._config.driver.login_cmd_template.format(**login_options)
 
-        cmd = f"/usr/bin/env {login_cmd}"
-        app.runtime.exec(cmd)
+        cmd = f"/usr/bin/env {login_cmd}".split(" ")
+        subprocess.run(cmd)
 
 
 @base.click_command_ex()

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -21,6 +21,7 @@
 
 import logging
 import os
+import shlex
 import subprocess
 
 import click
@@ -142,7 +143,7 @@ class Login(base.Base):
         login_options["lines"] = lines
         login_cmd = self._config.driver.login_cmd_template.format(**login_options)
 
-        cmd = f"/usr/bin/env {login_cmd}".split(" ")
+        cmd = shlex.split(f"/usr/bin/env {login_cmd}")
         subprocess.run(cmd)
 
 

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -26,7 +26,6 @@ import subprocess
 import click
 
 from molecule import scenarios, util
-from molecule.app import app
 from molecule.command import base
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #3435

Use of ansible runtime prevents of use interactive stdin/stdout,
and lack of split causing traces like this:

FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/env /bin/podman exec -e COLUMNS=254 -e LINES=60 -e TERM=bash -e TERM=xterm -ti mariadb_104 bash'
(because molecule tries to run whole command line as binary name
without arguments).