### PR TITLE
Replace toolset container image with creator-ee in the documentation

### DIFF
--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -281,14 +281,15 @@ setting up a virtualenv and testing an Ansible role via Molecule.
 
     }
 
-The following `Jenkinsfile` uses the Toolset image.
+The following `Jenkinsfile` uses the
+`Ansible Creator Execution Environment`_ image.
 
 .. code-block:: groovy
 
     pipeline {
       agent {
         docker {
-          image 'quay.io/ansible/toolset'
+          image 'quay.io/ansible/creator-ee'
           args '-v /var/run/docker.sock:/var/run/docker.sock'
         }
       }
@@ -419,3 +420,4 @@ conflict.
 .. _`issue1567_comment`: https://github.com/ansible-community/molecule/issues/1567#issuecomment-436876722
 .. _`Use Python Version Task`: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/use-python-version?view=azure-devops
 .. _`Azure Build Variables`: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services
+.. _`Ansible Creator Execution Environment`: https://github.com/ansible/creator-ee

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,12 +7,13 @@ Common Molecule Use Cases
 Running inside a container
 ==========================
 
-Molecule is built into a Docker image by the `Toolset`_ project.
+Molecule is built into a Docker image by the
+`Ansible Creator Execution Environment`_ project.
 
 Any questions or bugs related to use of Molecule from within a container
-should be addressed by the Toolset project.
+should be addressed by the Ansible Creator Execution Environment project.
 
-.. _`Toolset`: https://github.com/ansible-community/toolset
+.. _`Ansible Creator Execution Environment`: https://github.com/ansible/creator-ee
 
 Docker With Non-Privileged User
 ===============================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -146,12 +146,13 @@ some benefits:
 Docker
 ======
 
-Molecule is built into a Docker image by the `Toolset`_ project.
+Molecule is built into a Docker image by the
+`Ansible Creator Execution Environment`_ project.
 
 Any questions or bugs related to use of Molecule from within a container
-should be addressed by the Toolset project.
+should be addressed by the Ansible Creator Execution Environment project.
 
-.. _`Toolset`: https://github.com/ansible-community/toolset
+.. _`Ansible Creator Execution Environment`: https://github.com/ansible/creator-ee
 
 Source
 ======


### PR DESCRIPTION
The documentation still mentions the previous toolset image. The project https://github.com/ansible-community/toolset is archived and the `quay.io/ansible/toolset` image is deprecated. It is superseded by the `creator-ee` container from https://github.com/ansible/creator-ee and available at `quay.io/ansible/creator-ee`.