### PR TITLE
Change ansible-lint version since version 6.0.0 and greater doesn't work

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         entry: mypy src/
         pass_filenames: false
         additional_dependencies:
-          - ansible-lint>=5.1.2
+          - ansible-lint>=5.1.2,<6.0.0
           - click>=8.0.1
           - enrich>=1.2.5
           - importlib-metadata>=4.6.1
@@ -72,7 +72,7 @@ repos:
     hooks:
       - id: pylint
         additional_dependencies:
-          - ansible-lint>=5.1.2
+          - ansible-lint>=5.1.2,<6.0.0
           - enrich>=1.2.5
           - subprocess-tee>=0.2.0
           - testinfra

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible-lint >= 5.1.1 < 6.0.0  # only for the prerun functionality
+    ansible-lint >= 5.1.1, < 6.0.0  # only for the prerun functionality
     cerberus >= 1.3.1, !=1.3.3, !=1.3.4
     click >= 8.0, < 9
     click-help-colors >= 0.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible-lint >= 5.1.1  # only for the prerun functionality
+    ansible-lint >= 5.1.1 < 6.0.0  # only for the prerun functionality
     cerberus >= 1.3.1, !=1.3.3, !=1.3.4
     click >= 8.0, < 9
     click-help-colors >= 0.9


### PR DESCRIPTION
Closes #3498

molecule with version 3.4 depends on `prerun` module in `ansible-lint` but `ansible-lint` with version 6.0.0 and greater doesn't have `prerun` module.
We should restrict the version of `ansible-lint`.