### PR TITLE
Fix black dependency issue in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
     rev: 5.9.2
     hooks:
       - id: isort
-  - repo: https://github.com/python/black.git
-    rev: 21.7b0
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/src/molecule/test/unit/test_scenarios.py
+++ b/src/molecule/test/unit/test_scenarios.py
@@ -80,7 +80,7 @@ def test_print_matrix(capsys, _instance):
         _instance.print_matrix()
     result = chomp(strip_ansi_escape(capture.get()))
 
-    matrix_out = u"""---
+    matrix_out = """---
 default:
   - dependency
   - lint


### PR DESCRIPTION
Due to the following issue in black, pre-commit hook doesn't work correctly
https://github.com/psf/black/issues/2964

As same as the main branch, I've updated the pre-commit hook settings
https://github.com/ansible-community/molecule/blob/main/.pre-commit-config.yaml#L35