### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -4,6 +4,11 @@ on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   ack:
+    permissions:
+      contents: none
     uses: ansible-community/devtools/.github/workflows/ack.yml@main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,11 @@ on:
       - "releases/**"
       - "stable/**"
 
+permissions:
+  contents: read
+
 jobs:
   ack:
+    permissions:
+      contents: none
     uses: ansible-community/devtools/.github/workflows/push.yml@main


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
