### PR TITLE
Fix wrong environment variables being passed to ansible compat (#3404)

### DIFF
--- a/src/molecule/provisioner/ansible_playbook.py
+++ b/src/molecule/provisioner/ansible_playbook.py
@@ -44,7 +44,9 @@ class AnsiblePlaybook(object):
         self._playbook = playbook
         self._config = config
         self._cli = {}
-        self._env = util.merge_dicts(self._config.provisioner.env, self._config.runtime.environ)
+        self._env = util.merge_dicts(
+            self._config.provisioner.env, self._config.runtime.environ
+        )
 
     def bake(self):
         """

--- a/src/molecule/provisioner/ansible_playbook.py
+++ b/src/molecule/provisioner/ansible_playbook.py
@@ -44,7 +44,7 @@ class AnsiblePlaybook(object):
         self._playbook = playbook
         self._config = config
         self._cli = {}
-        self._env = self._config.provisioner.env
+        self._env = util.merge_dicts(self._config.provisioner.env, self._config.runtime.environ)
 
     def bake(self):
         """


### PR DESCRIPTION
You can find a  demo of this error here:
https://github.com/marblenix/molecule-bug-demo-3404/commits/main

In the body of each commit, details the commands that are needed to be run to reproduce the error with minimal setup, with the last one pushing a requirements.txt file to this branch. To see the error, it's recommended to be working on a machine that hasn't had `ansible-galaxy collection install` run on it before. If you are unable to reproduce the issue locally, try removing the cached roles and collections folders.

```sh
python3 -m venv .venv; source .venv/bin/activate
pip install pip wheel; pip install 'ansible-lint[core,yamllint]' 'molecule[docker,lint]'
molecule init role acme.my_new_role --driver-name docker
cd my_new_role

pip install --upgrade --force \
        git+https://github.com/ansible-community/molecule@main \
        git+https://github.com/ansible/ansible-compat@main \
        git+https://github.com/ansible/ansible@devel
molecule test
```

To test my changes, run:

```sh
pip install --upgrade --force git+https://github.com/marblenix/molecule@main
```

I ran the test suite by enabling actions on my fork. The tox parts failed when it needed the secrets, but the unit tests themselves still passed. https://github.com/marblenix/molecule/actions/runs/2193046395

Please note, this **_will not_** solve the issue with #3513. It does allow for a workaround to this bug by adding the following to a requirements.yml file:

```yaml
collections:
  - community.docker
```

--

The exact cause of this issue is this line here in ansible-compat: https://github.com/ansible/ansible-compat/blob/05d94d4d1b484b05c53c9b5844e4187d9872c258/src/ansible_compat/runtime.py#L515

The problem is ansible-compat is adding these environment variables to the runtime, and molecule is adding its own variables to the provisioner. Combining them seems to resolve the issue just fine.

To verify that this specific problem is resolved, run tests like so: `molecule --debug -v test`. The very last output of `DEBUG: SHELL REPLAY:` should include a line about ANSIBLE_COLLECTIONS_PATH being in `~/.cache/ansible-compat/DEADBEEF/collections:...`