### PR TITLE
Bugfix test init role and scenario

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,23 +27,23 @@ jobs:
           - tox_env: docs
             python-version: 3.9
           - tox_env: py38
-            PREFIX: PYTEST_REQPASS=457
+            PREFIX: PYTEST_REQPASS=459
             python-version: 3.8
             cover: true
           - tox_env: py39
-            PREFIX: PYTEST_REQPASS=457
+            PREFIX: PYTEST_REQPASS=459
             python-version: 3.9
             cover: true
           - tox_env: py310
-            PREFIX: PYTEST_REQPASS=457
+            PREFIX: PYTEST_REQPASS=459
             python-version: "3.10"
             cover: true
           - tox_env: py38-devel
-            PREFIX: PYTEST_REQPASS=457
+            PREFIX: PYTEST_REQPASS=459
             python-version: 3.8
             cover: true
           - tox_env: py310-devel
-            PREFIX: PYTEST_REQPASS=457
+            PREFIX: PYTEST_REQPASS=459
             python-version: "3.10"
             # see https://github.com/ansible-community/molecule/issues/3291
             experimental: true

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get remove -y ansible \
           && sudo apt-get update \
           && sudo apt-get install -y libvirt-dev python3-cryptography python3-jinja2 python3-yaml virtualenv \
-          && pip3 install --user ansible-core \
+          && pip3 install --user ansible-core ansible-lint\
           && echo "$HOME/.local/bin" >> $GITHUB_PATH
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
       - name: Validate that ansible works

--- a/src/molecule/test/functional/conftest.py
+++ b/src/molecule/test/functional/conftest.py
@@ -105,7 +105,7 @@ def idempotence(scenario_name):
 
 
 def init_role(temp_dir, driver_name):
-    role_directory = os.path.join(temp_dir.strpath, "myorg.myrole")
+    role_directory = os.path.join(temp_dir.strpath, "myrole")
 
     cmd = ["molecule", "init", "role", "myorg.myrole", "--driver-name", driver_name]
     assert run_command(cmd).returncode == 0
@@ -118,8 +118,8 @@ def init_role(temp_dir, driver_name):
 
 def init_scenario(temp_dir, driver_name):
     # Create role
-    role_directory = os.path.join(temp_dir.strpath, "test-init")
-    cmd = ["molecule", "init", "role", "test-init", "--driver-name", driver_name]
+    role_directory = os.path.join(temp_dir.strpath, "test_init")
+    cmd = ["molecule", "init", "role", "myorg.test_init", "--driver-name", driver_name]
     assert run_command(cmd).returncode == 0
     metadata_lint_update(role_directory)
 
@@ -134,7 +134,7 @@ def init_scenario(temp_dir, driver_name):
             "scenario",
             "test-scenario",
             "--role-name",
-            "test-init",
+            "test_init",
             "--driver-name",
             driver_name,
         ]

--- a/src/molecule/test/functional/test_command.py
+++ b/src/molecule/test/functional/test_command.py
@@ -186,15 +186,13 @@ def test_command_idempotence(scenario_to_test, with_scenario, scenario_name):
 
 @pytest.mark.serial
 @pytest.mark.parametrize("driver_name", [("delegated")], indirect=["driver_name"])
-@pytest.mark.xfail(reason="https://github.com/ansible-community/molecule/issues/3171")
-def test_command_init_role(temp_dir, driver_name, skip_test):
+def test_command_init_role(temp_dir, driver_name):
     init_role(temp_dir, driver_name)
 
 
 @pytest.mark.serial
 @pytest.mark.parametrize("driver_name", [("delegated")], indirect=["driver_name"])
-@pytest.mark.xfail(reason="https://github.com/ansible-community/molecule/issues/3171")
-def test_command_init_scenario(temp_dir, driver_name, skip_test):
+def test_command_init_scenario(temp_dir, driver_name):
     init_scenario(temp_dir, driver_name)
 
 


### PR DESCRIPTION
Enable the following tests

```txt
FAILED src/molecule/test/functional/test_command.py::test_command_init_role[delegated] - assert 1 == 0
FAILED src/molecule/test/functional/test_command.py::test_command_init_scenario[delegated] - assert 1 == 0
```

Fixes: #3171