### PR TITLE
Enable molecule dependency test

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,23 +27,23 @@ jobs:
           - tox_env: docs
             python-version: 3.9
           - tox_env: py38
-            PREFIX: PYTEST_REQPASS=459
+            PREFIX: PYTEST_REQPASS=461
             python-version: 3.8
             cover: true
           - tox_env: py39
-            PREFIX: PYTEST_REQPASS=459
+            PREFIX: PYTEST_REQPASS=461
             python-version: 3.9
             cover: true
           - tox_env: py310
-            PREFIX: PYTEST_REQPASS=459
+            PREFIX: PYTEST_REQPASS=461
             python-version: "3.10"
             cover: true
           - tox_env: py38-devel
-            PREFIX: PYTEST_REQPASS=459
+            PREFIX: PYTEST_REQPASS=461
             python-version: 3.8
             cover: true
           - tox_env: py310-devel
-            PREFIX: PYTEST_REQPASS=459
+            PREFIX: PYTEST_REQPASS=461
             python-version: "3.10"
             # see https://github.com/ansible-community/molecule/issues/3291
             experimental: true

--- a/src/molecule/test/functional/test_command.py
+++ b/src/molecule/test/functional/test_command.py
@@ -133,18 +133,12 @@ def test_command_create(scenario_to_test, with_scenario, scenario_name, tmp_path
             "delegated",
             "shell",
             id="shell",
-            marks=pytest.mark.xfail(
-                reason="https://github.com/ansible-community/molecule/issues/3171"
-            ),
         ),
         pytest.param(
             "dependency",
             "delegated",
             "ansible-galaxy",
             id="galaxy",
-            marks=pytest.mark.xfail(
-                reason="https://github.com/ansible-community/molecule/issues/3171"
-            ),
         ),
     ],
     indirect=["scenario_to_test", "driver_name", "scenario_name"],

--- a/src/molecule/test/scenarios/dependency/molecule/ansible-galaxy/converge.yml
+++ b/src/molecule/test/scenarios/dependency/molecule/ansible-galaxy/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   gather_facts: false
   tasks:
+    - name: Install requirements for collection community.molecule
+      pip:
+        name: molecule
+      delegate_to: localhost
+
     - name: Validate that collection was installed
       debug:
         msg: "{{ 'foo' | community.molecule.header }}"

--- a/src/molecule/test/scenarios/dependency/molecule/ansible-galaxy/molecule.yml
+++ b/src/molecule/test/scenarios/dependency/molecule/ansible-galaxy/molecule.yml
@@ -1,6 +1,9 @@
 ---
 dependency:
   name: galaxy
+  options:
+    role-file: molecule/ansible-galaxy/requirements.yml
+    requirements-file: molecule/ansible-galaxy/requirements.yml
 driver:
   name: delegated
 platforms:

--- a/src/molecule/test/scenarios/dependency/molecule/shell/converge.yml
+++ b/src/molecule/test/scenarios/dependency/molecule/shell/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   gather_facts: false
   tasks:
+    - name: Install requirements for collection community.molecule
+      pip:
+        name: molecule
+      delegate_to: localhost
+
     - name: Validate that collection was installed
       debug:
         msg: "{{ 'foo' | community.molecule.header }}"


### PR DESCRIPTION
Fix #3171 

Enable the following tests

```txt
FAILED src/molecule/test/functional/test_command.py::test_command_dependency[galaxy] - AssertionError: assert 2 == 0
FAILED src/molecule/test/functional/test_command.py::test_command_dependency[shell]
```