### PR TITLE
Docs: fix undocumented env vars

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -62,7 +62,7 @@ MOLECULE_FILE
 MOLECULE_ENV_FILE
    Path to molecule environment file
 MOLECULE_STATE_FILE
-   ?
+   Path to molecule state file, contains state of the instances (created, converged, etc.) usually ``~/.cache/molecule/<role-name>/<scenario-name>/state.yml``
 MOLECULE_INVENTORY_FILE
    Path to generated inventory file
 MOLECULE_EPHEMERAL_DIRECTORY

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -58,7 +58,7 @@ There are following environment variables available in ``molecule.yml``:
 MOLECULE_DEBUG
    If debug is turned on or off
 MOLECULE_FILE
-   Path to molecule config file
+   Path to molecule config file, usually ``~/.cache/molecule/<role-name>/<scenario-name>/molecule.yml``
 MOLECULE_ENV_FILE
    Path to molecule environment file
 MOLECULE_STATE_FILE

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -62,7 +62,7 @@ MOLECULE_FILE
 MOLECULE_ENV_FILE
    Path to molecule environment file
 MOLECULE_STATE_FILE
-   Path to molecule state file, contains state of the instances (created, converged, etc.) usually ``~/.cache/molecule/<role-name>/<scenario-name>/state.yml``
+   Path to molecule state file, contains state of the instances (created, converged, etc.), usually ``~/.cache/molecule/<role-name>/<scenario-name>/state.yml``
 MOLECULE_INVENTORY_FILE
    Path to generated inventory file
 MOLECULE_EPHEMERAL_DIRECTORY
@@ -72,7 +72,8 @@ MOLECULE_SCENARIO_DIRECTORY
 MOLECULE_PROJECT_DIRECTORY
    Path to your project directory
 MOLECULE_INSTANCE_CONFIG
-   ?
+   Path to the instance config file, contains instance name, connection, user, port, etc. (populated from driver), 
+   usually ``~/.cache/molecule/<role-name>/<scenario-name>/instance_config.yml``
 MOLECULE_DEPENDENCY_NAME
    Dependency type name, usually 'galaxy'
 MOLECULE_DRIVER_NAME

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -66,7 +66,7 @@ MOLECULE_STATE_FILE
 MOLECULE_INVENTORY_FILE
    Path to generated inventory file
 MOLECULE_EPHEMERAL_DIRECTORY
-   Path to generated directory, usually ``~/.cache/molecule/<scenario-name>``
+   Path to generated directory, usually ``~/.cache/molecule/<role-name>/<scenario-name>``
 MOLECULE_SCENARIO_DIRECTORY
    Path to scenario directory
 MOLECULE_PROJECT_DIRECTORY

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -64,7 +64,7 @@ MOLECULE_ENV_FILE
 MOLECULE_STATE_FILE
    Path to molecule state file, contains state of the instances (created, converged, etc.), usually ``~/.cache/molecule/<role-name>/<scenario-name>/state.yml``
 MOLECULE_INVENTORY_FILE
-   Path to generated inventory file
+   Path to generated inventory file, usually ``~/.cache/molecule/<role-name>/<scenario-name>/inventory/ansible_inventory.yml``
 MOLECULE_EPHEMERAL_DIRECTORY
    Path to generated directory, usually ``~/.cache/molecule/<role-name>/<scenario-name>``
 MOLECULE_SCENARIO_DIRECTORY

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -89,7 +89,7 @@ MOLECULE_VERBOSITY
 MOLECULE_VERIFIER_NAME
    Name of the verifier tool (usually 'ansible')
 MOLECULE_VERIFIER_TEST_DIRECTORY
-  ?
+   Path of the directory that contains verifier tests, usually ``<role_path>/<scenario-name>/<verifier-name>``
 
 
 .. _dependency:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -68,7 +68,7 @@ MOLECULE_INVENTORY_FILE
 MOLECULE_EPHEMERAL_DIRECTORY
    Path to generated directory, usually ``~/.cache/molecule/<role-name>/<scenario-name>``
 MOLECULE_SCENARIO_DIRECTORY
-   Path to scenario directory
+   Path to scenario directory, usually ``<role_path>/molecule/<scenario-name>``
 MOLECULE_PROJECT_DIRECTORY
    Path to your project directory
 MOLECULE_INSTANCE_CONFIG

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -72,7 +72,7 @@ MOLECULE_SCENARIO_DIRECTORY
 MOLECULE_PROJECT_DIRECTORY
    Path to your project (role) directory, usually ``<role_path>``
 MOLECULE_INSTANCE_CONFIG
-   Path to the instance config file, contains instance name, connection, user, port, etc. (populated from driver), 
+   Path to the instance config file, contains instance name, connection, user, port, etc. (populated from driver),
    usually ``~/.cache/molecule/<role-name>/<scenario-name>/instance_config.yml``
 MOLECULE_DEPENDENCY_NAME
    Dependency type name, usually 'galaxy'

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -58,22 +58,30 @@ There are following environment variables available in ``molecule.yml``:
 MOLECULE_DEBUG
    If debug is turned on or off
 MOLECULE_FILE
-   Path to molecule config file, usually ``~/.cache/molecule/<role-name>/<scenario-name>/molecule.yml``
+   Path to molecule config file, usually
+   ``~/.cache/molecule/<role-name>/<scenario-name>/molecule.yml``
 MOLECULE_ENV_FILE
    Path to molecule environment file, usually ``<role_path>/.env.yml``
 MOLECULE_STATE_FILE
-   Path to molecule state file, contains state of the instances (created, converged, etc.), usually ``~/.cache/molecule/<role-name>/<scenario-name>/state.yml``
+   Path to molecule state file, contains state of the instances
+   (created, converged, etc.). Usually
+   ``~/.cache/molecule/<role-name>/<scenario-name>/state.yml``
 MOLECULE_INVENTORY_FILE
-   Path to generated inventory file, usually ``~/.cache/molecule/<role-name>/<scenario-name>/inventory/ansible_inventory.yml``
+   Path to generated inventory file, usually
+   ``~/.cache/molecule/<role-name>/<scenario-name>/inventory/ansible_inventory.yml``
 MOLECULE_EPHEMERAL_DIRECTORY
-   Path to generated directory, usually ``~/.cache/molecule/<role-name>/<scenario-name>``
+   Path to generated directory,
+   usually ``~/.cache/molecule/<role-name>/<scenario-name>``
 MOLECULE_SCENARIO_DIRECTORY
-   Path to scenario directory, usually ``<role_path>/molecule/<scenario-name>``
+   Path to scenario directory,
+   usually ``<role_path>/molecule/<scenario-name>``
 MOLECULE_PROJECT_DIRECTORY
    Path to your project (role) directory, usually ``<role_path>``
 MOLECULE_INSTANCE_CONFIG
-   Path to the instance config file, contains instance name, connection, user, port, etc. (populated from driver),
-   usually ``~/.cache/molecule/<role-name>/<scenario-name>/instance_config.yml``
+   Path to the instance config file,
+   contains instance name, connection, user, port, etc.
+   (populated from driver). Usually
+   ``~/.cache/molecule/<role-name>/<scenario-name>/instance_config.yml``
 MOLECULE_DEPENDENCY_NAME
    Dependency type name, usually 'galaxy'
 MOLECULE_DRIVER_NAME
@@ -89,7 +97,8 @@ MOLECULE_VERBOSITY
 MOLECULE_VERIFIER_NAME
    Name of the verifier tool (usually 'ansible')
 MOLECULE_VERIFIER_TEST_DIRECTORY
-   Path of the directory that contains verifier tests, usually ``<role_path>/<scenario-name>/<verifier-name>``
+   Path of the directory that contains verifier tests,
+   usually ``<role_path>/<scenario-name>/<verifier-name>``
 
 
 .. _dependency:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -60,7 +60,7 @@ MOLECULE_DEBUG
 MOLECULE_FILE
    Path to molecule config file, usually ``~/.cache/molecule/<role-name>/<scenario-name>/molecule.yml``
 MOLECULE_ENV_FILE
-   Path to molecule environment file
+   Path to molecule environment file, usually ``<role_path>/.env.yml``
 MOLECULE_STATE_FILE
    Path to molecule state file, contains state of the instances (created, converged, etc.), usually ``~/.cache/molecule/<role-name>/<scenario-name>/state.yml``
 MOLECULE_INVENTORY_FILE

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -70,7 +70,7 @@ MOLECULE_EPHEMERAL_DIRECTORY
 MOLECULE_SCENARIO_DIRECTORY
    Path to scenario directory, usually ``<role_path>/molecule/<scenario-name>``
 MOLECULE_PROJECT_DIRECTORY
-   Path to your project directory
+   Path to your project (role) directory, usually ``<role_path>``
 MOLECULE_INSTANCE_CONFIG
    Path to the instance config file, contains instance name, connection, user, port, etc. (populated from driver), 
    usually ``~/.cache/molecule/<role-name>/<scenario-name>/instance_config.yml``


### PR DESCRIPTION
* Adds description for `MOLECULE_` env vars that was missing
* Adds default paths to all env vars that contain a path.

#### PR Type

    * Docs Pull Request