### PR TITLE
Pin chardet version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ zip_safe = False
 # These are required in actual runtime:
 install_requires =
     ansible-compat >= 2.1.0
+    chardet >= 4.0.0, < 5.0.0
     cerberus >= 1.3.1, !=1.3.3, !=1.3.4
     click >= 8.0, < 9
     click-help-colors >= 0.9


### PR DESCRIPTION
`requests==2.28.0` is not happy with `chardet==5.0.0`.

So `chardet==4.0.0` is required. 

### Error message

```
.tox/py38-devel/lib/python3.8/site-packages/requests/__init__.py:109: in <module>
    warnings.warn(
E   requests.exceptions.RequestsDependencyWarning: urllib3 (1.26.9) or chardet (5.0.0)/charset_normalizer (2.0.12) doesn't match a supported version!
____________ ERROR collecting src/molecule/test/unit/test_shell.py _____________
.tox/py38-devel/lib/python3.8/site-packages/requests/__init__.py:105: in <module>
    check_compatibility(
.tox/py38-devel/lib/python3.8/site-packages/requests/__init__.py:79: in check_compatibility
    assert (3, 0, 2) <= (major, minor, patch) < (5, 0, 0)
E   AssertionError
```

### Dependency tree

As we can see, `chardet>=3.0.2` will be installed (from binaryornot>=0.4.4->cookiecutter>=1.7.3->molecule>=3.6.0) (4.0.0)

```txt
❯ pip install 'molecule>=3.6.0'
Requirement already satisfied: molecule>=3.6.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (3.6.1)
Requirement already satisfied: rich>=9.5.1 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (12.4.1)
Requirement already satisfied: click<9,>=8.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (8.1.3)
Requirement already satisfied: PyYAML>=5.1 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (6.0)
Requirement already satisfied: Jinja2>=2.11.3 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (3.1.2)
Requirement already satisfied: importlib-metadata in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (4.11.3)
Requirement already satisfied: pluggy<2.0,>=0.7.1 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (1.0.0)
Requirement already satisfied: cookiecutter>=1.7.3 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (1.7.3)
Requirement already satisfied: packaging in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (21.3)
Requirement already satisfied: paramiko<3,>=2.5.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (2.11.0)
Requirement already satisfied: click-help-colors>=0.9 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (0.9.1)
Requirement already satisfied: ansible-compat>=1.0.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (1.0.0)
Requirement already satisfied: enrich>=1.2.7 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (1.2.7)
Requirement already satisfied: cerberus!=1.3.3,!=1.3.4,>=1.3.1 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from molecule>=3.6.0) (1.3.2)
Requirement already satisfied: cached-property~=1.5 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from ansible-compat>=1.0.0->molecule>=3.6.0) (1.5.2)
Requirement already satisfied: subprocess-tee>=0.3.5 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from ansible-compat>=1.0.0->molecule>=3.6.0) (0.3.5)
Requirement already satisfied: setuptools in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from cerberus!=1.3.3,!=1.3.4,>=1.3.1->molecule>=3.6.0) (47.1.0)
Requirement already satisfied: binaryornot>=0.4.4 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from cookiecutter>=1.7.3->molecule>=3.6.0) (0.4.4)
Requirement already satisfied: poyo>=0.5.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from cookiecutter>=1.7.3->molecule>=3.6.0) (0.5.0)
Requirement already satisfied: python-slugify>=4.0.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from cookiecutter>=1.7.3->molecule>=3.6.0) (6.1.2)
Requirement already satisfied: jinja2-time>=0.2.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from cookiecutter>=1.7.3->molecule>=3.6.0) (0.2.0)
Requirement already satisfied: requests>=2.23.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from cookiecutter>=1.7.3->molecule>=3.6.0) (2.27.1)
Requirement already satisfied: six>=1.10 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from cookiecutter>=1.7.3->molecule>=3.6.0) (1.16.0)
Requirement already satisfied: MarkupSafe>=2.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from Jinja2>=2.11.3->molecule>=3.6.0) (2.1.1)
Requirement already satisfied: bcrypt>=3.1.3 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from paramiko<3,>=2.5.0->molecule>=3.6.0) (3.2.2)
Requirement already satisfied: pynacl>=1.0.1 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from paramiko<3,>=2.5.0->molecule>=3.6.0) (1.5.0)
Requirement already satisfied: cryptography>=2.5 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from paramiko<3,>=2.5.0->molecule>=3.6.0) (37.0.2)
Requirement already satisfied: typing-extensions>=3.6.4 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from importlib-metadata->molecule>=3.6.0) (4.1.1)
Requirement already satisfied: zipp>=0.5 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from importlib-metadata->molecule>=3.6.0) (3.7.0)
Requirement already satisfied: commonmark<0.10.0,>=0.9.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from rich>=9.5.1->molecule>=3.6.0) (0.9.1)
Requirement already satisfied: pygments<3.0.0,>=2.6.0 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from rich>=9.5.1->molecule>=3.6.0) (2.12.0)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from packaging->molecule>=3.6.0) (3.0.7)
Requirement already satisfied: cffi>=1.1 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from bcrypt>=3.1.3->paramiko<3,>=2.5.0->molecule>=3.6.0) (1.15.0)
Requirement already satisfied: chardet>=3.0.2 in /Users/jackzhang/.pyenv/versions/3.7.10/lib/python3.7/site-packages (from binaryornot>=0.4.4->cookiecutter>=1.7.3->molecule>=3.6.0) (4.0.0)
```