### PR TITLE
Switch ansible@devel testing from py38 to py39

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -42,9 +42,9 @@ jobs:
             os: ubuntu-20.04
             python-version: "~3.11.0-0" # see https://github.com/actions/setup-python/issues/213#issuecomment-1146676713
             cover: true
-          - tox_env: py38-devel
+          - tox_env: py39-devel
             PREFIX: PYTEST_REQPASS=461
-            python-version: 3.8
+            python-version: 3.9
             cover: true
           - tox_env: py310-devel
             PREFIX: PYTEST_REQPASS=461


### PR DESCRIPTION
As next version of ansible already requires python >3.9, we need
to update our testing pipelines.
