### PR TITLE
Support ANSIBLE_COLLECTIONS_PATH environment var

### DIFF
--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -465,6 +465,15 @@ class Ansible(base.Base):
             ]
         )
 
+        if os.environ.get("ANSIBLE_COLLECTIONS_PATH", ""):
+            collections_path_list.extend(
+                list(
+                    map(
+                        util.abs_path, os.environ["ANSIBLE_COLLECTIONS_PATH"].split(":")
+                    )
+                )
+            )
+
         roles_path_list = [
             util.abs_path(
                 os.path.join(self._config.scenario.config.runtime.cache_dir, "roles")


### PR DESCRIPTION
This commit adds supports for reading ANSIBLE_COLLECTIONS_PATH from the environment, in a similar manner to how ANSIBLE_ROLES_PATH is handled.

—---

Fixes https://github.com/ansible-community/molecule/issues/3663