### PR TITLE
Fix schema

### DIFF
--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -468,6 +468,13 @@
     "VerifierModel": {
       "additionalProperties": false,
       "properties": {
+        "directory": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Directory",
+          "type": "string"
+        },
         "additional_files_or_dirs": {
           "items": {
             "type": "string"

--- a/src/molecule/test/unit/model/v2/test_verifier_section.py
+++ b/src/molecule/test/unit/model/v2/test_verifier_section.py
@@ -29,6 +29,7 @@ def _model_verifier_section_data():
         "verifier": {
             "name": "testinfra",
             "enabled": True,
+            "directory": "foo",
             "options": {"foo": "bar"},
             "env": {"FOO": "foo", "FOO_BAR": "foo_bar"},
             "additional_files_or_dirs": ["foo"],


### PR DESCRIPTION
_I am creating this new PR after rebasing @davedittrich's PR #3667.  I rebased the PR branch from #3667 onto `main`, but then @davedittrich closed his PR so I am opening this new one._

Description compiled from the original PR:
PR #3638 removed a central part of the schema that broke `pytest-testinfra`. I spent a little time looking into it and it looked like the schema validation is more a "does it parse" than "does it support all possible attributes."

A unit test was also broken: [`src/molecule/test/unit/model/v2/test_verifier_section.py`](https://github.com/ansible-community/molecule/pull/3638/files).