### PR TITLE
JSON Schema: Allow additionalProperties in ProvisionerConfigOptionsSshConnectionModel 

### DIFF
--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -414,7 +414,7 @@
       "type": "object"
     },
     "ProvisionerConfigOptionsSshConnectionModel": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "control_path": {
           "default": "%(directory)s/%%h-%%p-%%r",


### PR DESCRIPTION
Based on the discussion in the following [issue](https://github.com/ansible-community/molecule/issues/3714)

This change allow a molecule user to set any additional  [ssh_connection options](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ssh_connection.html) needed for the provisioner object in `molecule.yml`.