### PR TITLE
Add "default" as a valid docker "network_mode" in molecule.json schema

### DIFF
--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -225,7 +225,7 @@
         "network_mode": {
           "anyOf": [
             {
-              "enum": ["bridge", "host", "none"],
+              "enum": ["bridge", "default", "host", "none"],
               "type": "string"
             },
             {


### PR DESCRIPTION
As per discussion in: https://github.com/ansible-community/molecule/discussions/3723

Without the change in this PR, the molecule schema validation step fails and throw this "not so obvious" error: 

```console
molecule --debug syntax                                        
DEBUG    Validating schema /Users/My_User/ansible-role/molecule/default/molecule.yml.
CRITICAL Failed to validate /Users/My_User/ansible-role/molecule/default/molecule.yml

["'default' is not valid under any of the given schemas"]
```

And reference in: https://docs.ansible.com/ansible/latest/collections/community/docker/docker_container_module.html#parameter-network_mode