### PR TITLE
Accept any string for "network_mode" in molecule.json schema

### DIFF
--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -223,8 +223,16 @@
           "type": "string"
         },
         "network_mode": {
-          "title": "Network Mode",
-          "type": "string"
+          "anyOf": [
+            {
+              "enum": ["bridge", "default", "host", "none"],
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "title": "Network Mode"
         },
         "networks": {
           "items": {

--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -225,7 +225,7 @@
         "network_mode": {
           "anyOf": [
             {
-              "enum": ["bridge", "default", "host", "none"],
+              "enum": ["bridge", "host", "none"],
               "type": "string"
             },
             {

--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -225,7 +225,7 @@
         "network_mode": {
           "anyOf": [
             {
-              "enum": ["bridge", "host", "none"],
+              "enum": ["bridge", "default", "host", "none"],
               "type": "string"
             },
             {

--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -223,21 +223,8 @@
           "type": "string"
         },
         "network_mode": {
-          "anyOf": [
-            {
-              "enum": ["bridge", "host", "none"],
-              "type": "string"
-            },
-            {
-              "pattern": "^service:[a-zA-Z0-9:_.\\\\-]+$",
-              "type": "string"
-            },
-            {
-              "pattern": "^container:[a-zA-Z0-9][a-zA-Z0-9_.-]+$",
-              "type": "string"
-            }
-          ],
-          "title": "Network Mode"
+          "title": "Network Mode",
+          "type": "string"
         },
         "networks": {
           "items": {

--- a/tools/test-schema/test/molecule/default/molecule.yml
+++ b/tools/test-schema/test/molecule/default/molecule.yml
@@ -74,7 +74,7 @@ platforms:
       - /etc/ci/mirror_info.sh:/etc/ci/mirror_info.sh:ro
       - /etc/pki/rpm-gpg:/etc/pki/rpm-gpg
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    network_mode: service:vpn
+    network_mode: foo
     privileged: true
     environment: &env
       http_proxy: "{{ lookup('env', 'http_proxy') }}"


### PR DESCRIPTION
As mentioned by @felixfontein in https://github.com/ansible-community/molecule/pull/3724 `network_mode` can be any network name specified by a user and should not be limited to a specific set of strings or string patterns. 


