### PR TITLE
Fix running tox:dockerfile with docker secretservice enabled

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ skip_install = True
 passenv =
     CI
     CONTAINER_*
+    DISPLAY
     DOCKER_*
     GITHUB_*
     HOME


### PR DESCRIPTION
This PR fixes issue #3758 which was later migrated to discussion #3759.

As a short summary of the posts above.

The problem happens when you have configured `secretservice` as your `credstore` in your docker configfile (e.g. `~/.docker.config.json`)

running `tox -e dockerfile` launches the playbook `src/molecule/data/validate-dockerfile.yml` which then fails at image build taks with error 
> ansible_collections.community.docker.plugins.module_utils._api.credentials.errors.StoreError: Credentials store docker-credential-secretservice exited with "Cannot autolaunch D-Bus without X11 $DISPLAY"

Passing the `DISPLAY` environment variable to tox fixes the issue.