### PR TITLE
Fix ansible-lint install command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -101,7 +101,7 @@ is easily installed separately:
 
 .. code-block:: bash
 
-    $ python3 -m pip install --user "molecule ansible-lint"
+    $ python3 -m pip install --user "ansible-lint"
 
 Molecule uses the "delegated" driver by default. Other drivers can
 be installed separately from PyPI, most of them being included in


### PR DESCRIPTION
The documented command for installing `ansible-lint` was broken: the quotes consider `"molecule ansible-lint"` as a single package name. Anyway, we expect only `ansible-lint` in this document section.