### PR TITLE
Remove use of pytest-html

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ test = [
   "coverage >= 7.0.3",
   "filelock >= 3.9.0",
   "pexpect >= 4.8.0, < 5",
-  "pytest-html >= 3.2.0",
   "pytest-mock >= 3.10.0",
   "pytest-plus >= 0.4.0",
   "pytest-testinfra >= 7.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,15 +56,12 @@ platformdirs==2.6.2
 pluggy==1.0.0
 pre-commit==3.0.4
 ptyprocess==0.7.0
-py==1.11.0
 pycodestyle==2.10.0
 pycparser==2.21
 pyflakes==3.0.1
 pygments==2.14.0
 pyrsistent==0.19.3
 pytest==7.2.1
-pytest-html==3.2.0
-pytest-metadata==2.0.4
 pytest-mock==3.10.0
 pytest-plus==0.4.0
 pytest-testinfra==7.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1
     # Temporare remove "-n auto" as it seems to break coverage on this project.
-    _EXTRAS=-l --html={envlogdir}/reports.html --self-contained-html
+    _EXTRAS=-l
 deps =
     # py,py{39,310,311,312}: --editable .[docker,lint,podman,test,windows]
     devel: git+https://github.com/ansible/ansible#egg=ansible-core


### PR DESCRIPTION
Due to current maintenance status of pytest-html we stop using it.

Related: https://github.com/pytest-dev/pytest-html/pull/575
Related: https://github.com/pytest-dev/pytest-html/issues/570
