### PR TITLE
Fix documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,8 +29,7 @@ By default, `Molecule` will check whether the role name follows the name
 standard. If not, it will raise an error.
 
 If computed fully qualified role name does not follow current galaxy
-requirements, you can ignore it by adding [role_name_check:
-1]{.title-ref} inside the configuration file.
+requirements, you can ignore it by adding `role_name_check:1` inside the configuration file.
 
 It is strongly recommended to follow the name standard of
 [namespace](https://galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespace-limitations)
@@ -138,9 +137,9 @@ managers.
 
 Molecule uses [Ansible](#ansible-1) to manage instances to operate on.
 Molecule supports any provider [Ansible](#ansible-1) supports. This work
-is offloaded to the [provisioner]{.title-ref}.
+is offloaded to the `provisioner`.
 
-The driver's name is specified in [molecule.yml]{.title-ref}, and can
+The driver's name is specified in `molecule.yml`, and can
 be overridden on the command line. Molecule will remember the last
 successful driver used, and continue to use the driver for all
 subsequent subcommands, or until the instances are destroyed by

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -36,7 +36,7 @@ template can be customized as needed to create the desired modifications
 to the Docker image used in the scenario.
 
 Note: `platforms[*].pre_build_image` defaults to `true` in each
-scenario's generated [molecule.yml]{.title-ref} file.
+scenario's generated `molecule.yml` file.
 
 ## Docker With Non-Privileged User
 
@@ -47,7 +47,7 @@ follows.
 
 Note: The `Dockerfile` templating and image building processes are only
 done for scenarios with `pre_build_image = False`, which is not the
-default setting in generated [molecule.yml]{.title-ref} files.
+default setting in generated `molecule.yml` files.
 
 To modify the Docker image to support running as normal user:
 
@@ -347,7 +347,7 @@ shared-tests
 
 Tests and playbooks can be shared across scenarios.
 
-In this example the [tests]{.title-ref} directory lives in a shared
+In this example the `tests` directory lives in a shared
 location and `molecule.yml` points to the shared tests.
 
 ```yaml
@@ -356,8 +356,8 @@ verifier:
   directory: ../resources/tests/
 ```
 
-In this second example the actions [create]{.title-ref},
-[destroy]{.title-ref}, [converge]{.title-ref} and [prepare]{.title-ref}
+In this second example the actions `create`,
+`destroy`, `converge` and `prepare`
 are loaded from a shared directory.
 
 ```yaml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,7 +115,7 @@ components that Molecule provides. These are:
 - The [scenario][] definition.
   Molecule relies on this configuration to control the scenario
   sequence order.
-- The [verifier](/configuration/#verifier)` framework. Molecule
+- The [verifier](/configuration/#verifier) framework. Molecule
   uses Ansible by default to provide a way to write specific state
   checking tests (such as deployment smoke tests) on the target
   instance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,4 @@
+---
 site_name: Ansible Molecule
 site_url: https://molecule.readthedocs.io/
 repo_url: https://github.com/ansible-community/molecule
@@ -99,14 +100,11 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets:
       check_paths: true
-  - pymdownx.superfences
   - pymdownx.magiclink:
       repo_url_shortener: true
       repo_url_shorthand: true
       social_url_shorthand: true
       social_url_shortener: true
-      user: facelessuser
-      repo: pymdown-extensions
       normalize_issue_symbols: true
   - pymdownx.tabbed:
       alternate_style: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,9 +51,9 @@ extra:
       link: https://github.com/ansible-community/molecule
 
 nav:
-  - home: index.md
+  - Home: index.md
   - installation.md
-  - using:
+  - Using:
       - getting-started.md
       - usage.md
       - configuration.md

--- a/src/molecule/dependency/ansible_galaxy/__init__.py
+++ b/src/molecule/dependency/ansible_galaxy/__init__.py
@@ -63,6 +63,7 @@ class AnsibleGalaxy(Base):
           name: galaxy
           env:
             FOO: bar
+    ```
     """
 
     def __init__(self, config):

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -38,7 +38,7 @@ LOG = logging.getLogger(__name__)
 
 class Ansible(base.Base):
     """
-    `Ansible`_ is the default provisioner.  No other provisioner will be \
+    `Ansible` is the default provisioner.  No other provisioner will be \
     supported.
 
     Molecule's provisioner manages the instances lifecycle.  However, the user
@@ -70,7 +70,7 @@ class Ansible(base.Base):
 
     !!! note
 
-        Molecule will remove any options matching '^[v]+$', and pass ``-vvv``
+        Molecule will remove any options matching `^[v]+$`, and pass ``-vvv``
         to the underlying ``ansible-playbook`` command when executing
         `molecule --debug`.
 


### PR DESCRIPTION
I fixed some minor documentation errors. Besides that, I also capitalized the navigation entries "Home" and "Using" and removed the duplicate `pymdownx.superfences` entry in the `markdown_extensions` dict from the `mkdocs.yml` config.