### PR TITLE
Add `consider-using-in` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,6 @@ disable = [
   "broad-except",
   "consider-merging-isinstance",
   # We will clean this up in a dedicated refactoring commit
-  "consider-using-in",
   "dangerous-default-value",
   "duplicate-code",
   "fixme",

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -69,7 +69,7 @@ def list(ctx, scenario_name, format):  # pragma: no cover
         statuses.extend(base.execute_subcommand(scenario.config, subcommand))
 
     headers = [text.title(name) for name in Status._fields]
-    if format == "simple" or format == "plain":
+    if format in ["simple", "plain"]:
         table_format = format  # "simple"
 
         if format == "plain":


### PR DESCRIPTION
The `consider-using-in` check ensures that we are using the `in` keyword when multiple comparisons are made with the same variable using the logical OR (or) operator. Using `in` keyword instead of multiple comparisons with `or` operator can help improve code readability and maintainability, and it can also help avoid potential issues with precedence and logic in complex conditions.