### PR TITLE
Add `no-value-for-parameter` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ disable = [
   "missing-module-docstring",
   "no-member",
   "no-self-argument",
-  "no-value-for-parameter",
   "not-callable",
   "protected-access",
   "redefined-builtin",

--- a/src/molecule/__main__.py
+++ b/src/molecule/__main__.py
@@ -23,9 +23,19 @@ import click
 from molecule.shell import main
 
 
-def main(ctx):
-    if __name__ == "__main__":
-        # Creating a click context object
-        ctx = click.Context()
-        # Providing values for the required arguments when calling main() function
-        main(ctx=ctx, debug=True, verbose=False, base_config=None, env_file=None)
+def func(ctx: click.Context) -> None:
+    # Creating a click context object
+    click_ctx = click.Context(command=None)
+    # Providing values for the required arguments when calling main() function
+    main(
+        command=None,
+        ctx=click_ctx,
+        debug=True,
+        verbose=False,
+        base_config=None,
+        env_file=None,
+    )
+
+
+if __name__ == "__main__":
+    func(click.Context(command=None))

--- a/src/molecule/__main__.py
+++ b/src/molecule/__main__.py
@@ -18,8 +18,14 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 """Molecule CLI main entry point."""
+import click
 
 from molecule.shell import main
 
-if __name__ == "__main__":
-    main()
+
+def main(ctx):
+    if __name__ == "__main__":
+        # Creating a click context object
+        ctx = click.Context()
+        # Providing values for the required arguments when calling main() function
+        main(ctx=ctx, debug=True, verbose=False, base_config=None, env_file=None)

--- a/src/molecule/test/unit/test_shell.py
+++ b/src/molecule/test/unit/test_shell.py
@@ -18,6 +18,7 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import click
 import pytest
 
 from molecule import shell
@@ -25,4 +26,14 @@ from molecule import shell
 
 def test_shell():
     with pytest.raises(SystemExit):
-        shell.main()
+        # Creating a click context object
+        ctx = click.Context()
+        # Providing values for the required arguments when calling main() function
+        shell.main(
+            command=None,
+            ctx=ctx,
+            debug=True,
+            verbose=False,
+            base_config=None,
+            env_file=None,
+        )

--- a/src/molecule/test/unit/test_shell.py
+++ b/src/molecule/test/unit/test_shell.py
@@ -27,7 +27,7 @@ from molecule import shell
 def test_shell():
     with pytest.raises(SystemExit):
         # Creating a click context object
-        ctx = click.Context()
+        ctx = click.Context(command=None)
         # Providing values for the required arguments when calling main() function
         shell.main(
             command=None,


### PR DESCRIPTION
The `no-value-for-parameter` check ensures that no function is called with missing or incomplete arguments. 