### PR TITLE
Add `unnecessary-lambda` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ disable = [
   "too-many-public-methods",
   "unidiomatic-typecheck",
   "unnecessary-comprehension",
-  "unnecessary-lambda",
   # Next rule was added because we cannot adjust the open calls during minor
   # releases since there is no guarantee that this will not break existing
   # scenarios (right now, we have no idea what encoding files that molecule

--- a/src/molecule/test/unit/conftest.py
+++ b/src/molecule/test/unit/conftest.py
@@ -19,7 +19,6 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import copy
-import functools
 import os
 import shutil
 from collections.abc import Generator
@@ -109,7 +108,11 @@ def molecule_data(
         _molecule_verifier_section_data,
     ]
 
-    return functools.reduce(lambda x, y: util.merge_dicts(x, y), fixtures)
+    merged_dict = {}
+    for fixture in fixtures:
+        merged_dict.update(fixture)
+
+    return merged_dict
 
 
 @pytest.fixture()


### PR DESCRIPTION
The `unnecessary-lambda` check ensures that we are not using a lambda function unnecessarily in our Python code, where a regular function or a built-in function could be used instead, which ultimately helps to make our code more readable and efficient.