### PR TITLE
Add `unidiomatic-typecheck` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,6 @@ disable = [
   "too-many-ancestors",
   "too-many-arguments",
   "too-many-public-methods",
-  "unidiomatic-typecheck",
-  "unnecessary-comprehension",
   # Next rule was added because we cannot adjust the open calls during minor
   # releases since there is no guarantee that this will not break existing
   # scenarios (right now, we have no idea what encoding files that molecule

--- a/src/molecule/test/unit/model/v2/test_driver_section.py
+++ b/src/molecule/test/unit/model/v2/test_driver_section.py
@@ -71,9 +71,9 @@ def test_driver_has_errors(_config):
     base_error_msg = "is not one of ['azure', 'ec2', 'delegated', 'docker', 'containers', 'openstack', 'podman', 'vagrant', 'digitalocean', 'gce', 'libvirt', 'lxd', 'molecule-*', 'molecule_*', 'custom-*', 'custom_*']"
 
     driver_name = str(_config["driver"]["name"])
-    if type(_config["driver"]["name"]) is str:
+    if isinstance(_config["driver"]["name"], str):
         # add single quotes for string
-        driver_name = f"'{driver_name}'"
+        driver_name = f"'{_config['driver']['name']}'"
 
     error_msg = [" ".join((driver_name, base_error_msg))]
     assert error_msg == schema_v3.validate(_config)


### PR DESCRIPTION
The  `unidiomatic-typecheck` ensures that we are using the `isinstance()` built-in function for type checking which is more idiomatic in Python for type-checking as compared to the `type()` built-in function 