### PR TITLE
Use api to get driver schema file

### DIFF
--- a/src/molecule/driver/base.py
+++ b/src/molecule/driver/base.py
@@ -271,6 +271,9 @@ class Driver:
             return p
         return None
 
+    def schema_file(self):
+        return None
+
     def modules_dir(self):
         """Return path to ansible modules included with driver."""
         p = os.path.join(self._path, "modules")

--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -20,9 +20,11 @@
 """Delegated Driver Module."""
 
 import logging
+import os
 
 from molecule import util
 from molecule.api import Driver
+from molecule.data import __file__ as data_module
 
 LOG = logging.getLogger(__name__)
 
@@ -253,3 +255,6 @@ class Delegated(Driver):
     def sanity_checks(self):
         # Note(decentral1se): Cannot implement driver specifics are unknown
         pass
+
+    def schema_file(self):
+        return os.path.join(os.path.dirname(data_module), "driver.json")


### PR DESCRIPTION
Current code is assuming that the molecule driver are inside a molecule_$driver python resource, which is not the case. For instance, vagrant plugin is in molecule_plugins.

As a solution:
- extend driver class to provide a schema_file() member, allowing to return a path to the driver.json file,
- replace schema_v3 code to use molecule api and get the schema file path thanks to the new schema_file().