### PR TITLE
Improve documentation for upgrade scenario

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,6 +95,13 @@ installation command would look like this:
 $ python3 -m pip install --user "molecule-plugins[podman]"
 ```
 
+!!! warning
+
+    If you upgrade molecule from previous versions, make sure to remove
+    previously installed drivers like for instance `molecule-podman` or
+    `molecule-vagrant` since those are now available in the `molecule-plugins`
+    package.
+
 Installing molecule package also installed its main script `molecule`,
 usually in `PATH`. Users should know that molecule can also be called as
 a python module, using `python -m molecule ...`. This alternative method


### PR DESCRIPTION
If one upgrade from previous molecule versions, and since drivers are now provided by the `molecule-plugins` package, `molecule-podman|docker|vagrant` packages needs to be removed.

See: https://github.com/ansible-community/molecule/issues/3895