### PR TITLE
Avoid using incompatible ansible-compat version

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,4 +1,4 @@
-ansible-compat >= 2.2.0
+ansible-compat >= 2.2.0, < 4.0.0
 ansible-core >= 2.12.10
 click >= 8.0, < 9
 click-help-colors >= 0.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
         entry: mypy src/
         pass_filenames: false
         additional_dependencies:
-          - ansible-compat>=2.2.0
+          - ansible-compat>=2.2.0,<4.0.0
           - click>=8.0.1
           - enrich>=1.2.7
           - importlib-metadata>=4.6.1
@@ -81,7 +81,7 @@ repos:
         args:
           - --output-format=colorized
         additional_dependencies:
-          - ansible-compat>=2.2.0
+          - ansible-compat>=2.2.0,<4.0.0
           - click
           - click-help-colors
           - cookiecutter


### PR DESCRIPTION
This is a temporary fix, until we switch to use the newer version.

Related: https://github.com/ansible/ansible-compat/discussions/257#discussioncomment-5791460
Related: https://github.com/ansible/ansible-compat/issues/260