### PR TITLE
fix tests for commands `molecule init role` and `molecule init scenario`

### DIFF
--- a/src/molecule/command/init/role.py
+++ b/src/molecule/command/init/role.py
@@ -90,7 +90,7 @@ class Role(base.Base):
 
         if namespace:
             # we need to inject namespace info into meta/main.yml
-            cmd = [
+            cmd_meta = [
                 "ansible",
                 "localhost",
                 "-o",  # one line output
@@ -99,7 +99,18 @@ class Role(base.Base):
                 "-a",
                 f'path={role_name}/meta/main.yml line="  namespace: {namespace}" insertafter="  author: your name"',
             ]
-            util.run_command(cmd, check=True)
+            util.run_command(cmd_meta, check=True)
+            # we need to inject namespace info into tests/test.yml
+            cmd_tests = [
+                "ansible",
+                "localhost",
+                "-o",  # one line output
+                "-m",
+                "lineinfile",
+                "-a",
+                f'path={role_name}/tests/test.yml line="    - {namespace}.{role_name}" regex="^(.*)  - {role_name}"',
+            ]
+            util.run_command(cmd_tests, check=True)
 
         scenario_base_directory = os.path.join(role_directory, role_name)
         templates = [

--- a/src/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/src/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -9,9 +9,10 @@
 
     # TODO: Developer must implement and populate 'server' variable
 
-    - when: server.changed | default(false) | bool
+    - name: Create instance config
+      when: server.changed | default(false) | bool  # noqa no-handler
       block:
-        - name: Populate instance config dict
+        - name: Populate instance config dict  # noqa jinja
           ansible.builtin.set_fact:
             instance_conf_dict: {
               'instance': "{{ }}",

--- a/src/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/src/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -22,5 +22,5 @@
           {{ instance_conf | to_json | from_json | to_yaml }}
         dest: "{{ molecule_instance_config }}"
         mode: 0600
-      when: server.changed | default(false) | bool
+      when: server.changed | default(false) | bool  # noqa no-handler
 {%- endraw %}

--- a/src/molecule/test/functional/.ansible-lint
+++ b/src/molecule/test/functional/.ansible-lint
@@ -1,12 +1,12 @@
+---
 # ansible-lint config for functional testing, used to bypass expected metadata
 # errors in molecule-generated roles. Loaded via the metadata_lint_update
 # pytest helper. For reference, see "E7xx - metadata" in:
-#  https://docs.ansible.com/ansible-lint/rules/default_rules.html
+
+# https://docs.ansible.com/ansible-lint/rules/default_rules.html
+
 skip_list:
-  # metadata/201 - Trailing whitespace
-  - '201'
-  # metadata/701 - Role info should contain platforms
-  - '701'
-  # metadata/703 - Should change default metadata: <field>"
-  - '703'
+  - meta-incorrect
+  - schema[meta]
+  - name[play]
 # See https://github.com/ansible/ansible/issues/63734

--- a/src/molecule/test/functional/conftest.py
+++ b/src/molecule/test/functional/conftest.py
@@ -164,7 +164,8 @@ def metadata_lint_update(role_directory: str) -> None:
     # the customize ansible-lint config is used.
     with change_dir_to(role_directory):
         cmd = ["ansible-lint", "."]
-    assert run_command(cmd).returncode == 0
+        result = run_command(cmd)
+    assert result.returncode == 0
 
 
 def list_cmd(x):


### PR DESCRIPTION
Currently, the tests fail for `test_command_init_role` and `test_command_init_scneario`. The tests execute `ansible-lint` on the newly-created roles and the linter recently got more restrictive, so we now have to adapt.

There are still two failures with Python 3.11 and ansible-core devel. `ansible-compat` calls `ansible-galaxy collection list --format=json` internally (https://github.com/ansible/ansible-compat/blob/d30965cd023b4116f6e959ace0e4dbf219677952/src/ansible_compat/runtime.py#LL235C20-L235C20) and due to some unknown reason it is executed with elevated verbosity producing broken json output. The output begins with:
```
Using molecule/.ansible.cfg as config file
{"/home/daniel/.ansible/collections/ansible_collections": {"ansible.posix": {"version": "1.5.1"},

.
.
.
```