### PR TITLE
`tox -e deps` needs to be allowed to run git

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,8 @@ commands =
   -pre-commit autoupdate
   # We fail if files are modified at the end
   git diff --exit-code
+allowlist_externals =
+    git
 
 [testenv:docs]
 description = Build documentation


### PR DESCRIPTION
Running `tox -e deps` fails:

```
$ tox -e deps 
deps: commands[0]> python -m pre_commit run --all --show-diff-on-failure --hook-stage manual pip-compile
pip-compile..............................................................Passed
pip-compile-upgrade......................................................Passed
lock.....................................................................Passed
deps: commands[1]> pre-commit autoupdate
[https://github.com/pre-commit/mirrors-prettier] updating v3.0.0-alpha.6 -> v3.0.0-alpha.9-for-vscode
[https://github.com/codespell-project/codespell] already up to date!
[https://github.com/psf/black] already up to date!
[https://github.com/pre-commit/pre-commit-hooks.git] already up to date!
[https://github.com/adrienverge/yamllint.git] updating v1.30.0 -> v1.32.0
[https://github.com/charliermarsh/ruff-pre-commit] updating v0.0.262 -> v0.0.270
[https://github.com/pre-commit/mirrors-mypy] updating v1.2.0 -> v1.3.0
[https://github.com/pycqa/pylint] already up to date!
[https://github.com/jazzband/pip-tools] already up to date!
deps: commands[2]> git diff --exit-code
deps: failed with git is not allowed, use allowlist_externals to allow it
  deps: FAIL code 1 (42.35 seconds)
  evaluation failed :( (42.42 seconds)
```