### PR TITLE
Adds Support for Shell Type Instance Param to Delegated Driver

### DIFF
--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -54,6 +54,7 @@ class Delegated(Driver):
           instance: instance_name
           port: ssh_port_as_string
           user: ssh_user
+          shell_type: sh
           password: ssh_password  # mutually exclusive with identity_file
           become_method: valid_ansible_become_method  # optional
           become_pass: password_if_required  # optional
@@ -64,6 +65,7 @@ class Delegated(Driver):
           port: winrm_port_as_string
           user: winrm_user
           password: winrm_password
+          shell_type: powershell
           winrm_transport: ntlm/credssp/kerberos
           winrm_cert_pem: <path to the credssp public certificate key>
           winrm_cert_key_pem: <path to the credssp private certificate key>
@@ -212,6 +214,11 @@ class Delegated(Driver):
                     conn_dict["ansible_ssh_common_args"] = " ".join(
                         self.ssh_connection_options,
                     )
+                if d.get("shell_type", None):
+                    conn_dict["ansible_shell_type"] = d.get(
+                        "shell_type",
+                    )
+
                 if d.get("password", None):
                     conn_dict["ansible_password"] = d.get("password")
                     # Based on testinfra documentation, ansible password must be passed via ansible_ssh_pass

--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -196,7 +196,7 @@ class Delegated(Driver):
         return {"instance": instance_name}
 
     def ansible_connection_options(self, instance_name):
-        # list of tuples describing mapable instance params and default values
+        # list of tuples describing mappable instance params and default values
         instance_params = [
             ("become_pass", None),
             ("become_method", False),
@@ -211,7 +211,7 @@ class Delegated(Driver):
             try:
                 d = self._get_instance_config(instance_name)
                 conn_dict = {}
-                # Check if optional mapable params are in the instance config
+                # Check if optional mappable params are in the instance config
                 for i in instance_params:
                     if d.get(i[0], i[1]):
                         conn_dict["ansible_" + i[0]] = d.get(i[0])

--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -215,9 +215,7 @@ class Delegated(Driver):
                         self.ssh_connection_options,
                     )
                 if d.get("shell_type", None):
-                    conn_dict["ansible_shell_type"] = d.get(
-                        "shell_type",
-                    )
+                    conn_dict["ansible_shell_type"] = d.get("shell_type")
 
                 if d.get("password", None):
                     conn_dict["ansible_password"] = d.get("password")


### PR DESCRIPTION
Addresses https://github.com/ansible-community/molecule/issues/3930

This bugfix (although it could be seen as a feature) adds missing support for the `shell_type` param in the Molecule instance for the `delegated` driver - this is then mapped to `ansible_shell_type` in the Molecule managed inventory.