### PR TITLE
Make driver optional in molecule.yml file

### DIFF
--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -569,7 +569,7 @@
       "$ref": "#/$defs/VerifierModel"
     }
   },
-  "required": ["driver", "platforms"],
+  "required": ["platforms"],
   "title": "Molecule Scenario Schema",
   "type": "object"
 }


### PR DESCRIPTION
While molecule itself does not require driver to be defined,
our schema wrongly required it.
