### PR TITLE
src/molecule/driver/delegated.py: Fix connection plugin name setting

### DIFF
--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -214,7 +214,7 @@ class Delegated(Driver):
                 # Check if optional mappable params are in the instance config
                 for i in instance_params:
                     if d.get(i[0], i[1]):
-                        conn_dict["ansible_" + i[0]] = d.get(i[0])
+                        conn_dict["ansible_" + i[0]] = d.get(i[0], i[1])
 
                 conn_dict["ansible_user"] = d.get("user")
                 conn_dict["ansible_host"] = d.get("address")


### PR DESCRIPTION
In ansible_connection_options(), when setting connection plugin name, the code does:

                for i in instance_params:
                     if d.get(i[0], i[1]):
                         conn_dict["ansible_" + i[0]] = d.get(i[0])

Looking at instance_params, for the connection, there's a default value neither None nor False, leading to the the being true and setting ansible_connection to d.get(i[0]), which may not be defined. In this case, this will lead to ansible_connection being set to None. This will lead to troubles. For instance, when using 'meta: reset_connection', ansible in _execute_meta() will call plugin_loader.connection_loader.get() with first param being None, leading to :
ERROR! Unexpected Exception, this is probably a bug: 'NoneType' object has no attribute 'startswith'

So, ensure that the default value is set when setting conn_dict.

Fixes: 5b750ff4e829df934d159e1bfbd0cc433139f71c ("Adds Support for Shell Type Instance Param to Delegated Driver")