### PR TITLE
Temporary disable support for external drivers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,10 @@ changelog = "https://github.com/ansible-community/molecule/releases"
 [project.scripts]
 molecule = "molecule.__main__:main"
 
-[project.entry-points."molecule.driver"]
+[project.entry-points."molecule.driver.next"]
 delegated = "molecule.driver.delegated:Delegated"
 
-[project.entry-points."molecule.verifier"]
+[project.entry-points."molecule.verifier.next"]
 testinfra = "molecule.verifier.testinfra:Testinfra"
 ansible = "molecule.verifier.ansible:Ansible"
 

--- a/src/molecule/api.py
+++ b/src/molecule/api.py
@@ -48,9 +48,9 @@ class IncompatibleMoleculeRuntimeWarning(MoleculeRuntimeWarning):
 def drivers(config=None) -> UserListMap:
     """Return list of active drivers."""
     plugins = UserListMap()
-    pm = pluggy.PluginManager("molecule.driver")
+    pm = pluggy.PluginManager("molecule.driver.next")
     try:
-        pm.load_setuptools_entrypoints("molecule.driver")
+        pm.load_setuptools_entrypoints("molecule.driver.next")
     except (Exception, SystemExit):
         # These are not fatal because a broken driver should not make the entire
         # tool unusable.
@@ -68,9 +68,9 @@ def drivers(config=None) -> UserListMap:
 def verifiers(config=None) -> UserListMap:
     """Return list of active verifiers."""
     plugins = UserListMap()
-    pm = pluggy.PluginManager("molecule.verifier")
+    pm = pluggy.PluginManager("molecule.verifier.next")
     try:
-        pm.load_setuptools_entrypoints("molecule.verifier")
+        pm.load_setuptools_entrypoints("molecule.verifier.next")
     except Exception:
         # These are not fatal because a broken verifier should not make the entire
         # tool unusable.


### PR DESCRIPTION
In order to avoid breaking molecule v6 due to 3rd drivers that
were not updated to the new API, we change the entry-points
so we would ignore them.
