### PR TITLE
Avoid reinstalling dependencies

### DIFF
--- a/src/molecule/dependency/ansible_galaxy/base.py
+++ b/src/molecule/dependency/ansible_galaxy/base.py
@@ -52,7 +52,7 @@ class AnsibleGalaxyBase(base.Base):
     @property
     def default_options(self):
         d = {
-            "force": True,
+            "force": False,
         }
         if self._config.debug:
             d["vvv"] = True

--- a/src/molecule/test/a_unit/dependency/ansible_galaxy/test_collections.py
+++ b/src/molecule/test/a_unit/dependency/ansible_galaxy/test_collections.py
@@ -70,7 +70,7 @@ def test_config_private_member(_instance):
 
 
 def test_default_options_property(_instance, role_file):
-    x = {"requirements-file": role_file, "force": True}
+    x = {"requirements-file": role_file, "force": False}
 
     assert x == _instance.default_options
 
@@ -95,7 +95,7 @@ def test_enabled_property(_instance):
 @pytest.mark.parametrize("config_instance", ["_dependency_section_data"], indirect=True)
 def test_options_property(_instance, role_file):
     x = {
-        "force": True,
+        "force": False,
         "requirements-file": role_file,
         "foo": "bar",
         "v": True,
@@ -108,7 +108,7 @@ def test_options_property(_instance, role_file):
 def test_options_property_handles_cli_args(role_file, _instance):
     _instance._config.args = {"debug": True}
     x = {
-        "force": True,
+        "force": False,
         "requirements-file": role_file,
         "foo": "bar",
         "vvv": True,
@@ -131,7 +131,6 @@ def test_collections_bake(_instance, role_file):
         "install",
         "--foo",
         "bar",
-        "--force",
         "--requirements-file",
         role_file,
         "-v",

--- a/src/molecule/test/a_unit/dependency/ansible_galaxy/test_roles.py
+++ b/src/molecule/test/a_unit/dependency/ansible_galaxy/test_roles.py
@@ -69,7 +69,7 @@ def test_config_private_member(_instance):
 
 
 def test_default_options_property(_instance, role_file):
-    x = {"role-file": role_file, "force": True}
+    x = {"role-file": role_file, "force": False}
 
     assert x == _instance.default_options
 
@@ -94,7 +94,7 @@ def test_enabled_property(_instance):
 @pytest.mark.parametrize("config_instance", ["_dependency_section_data"], indirect=True)
 def test_options_property(_instance, role_file):
     x = {
-        "force": True,
+        "force": False,
         "role-file": role_file,
         "foo": "bar",
         "v": True,
@@ -107,7 +107,7 @@ def test_options_property(_instance, role_file):
 def test_options_property_handles_cli_args(role_file, _instance):
     _instance._config.args = {"debug": True}
     x = {
-        "force": True,
+        "force": False,
         "role-file": role_file,
         "foo": "bar",
         "vvv": True,
@@ -129,7 +129,6 @@ def test_galaxy_bake(_instance, role_file):
         "install",
         "--foo",
         "bar",
-        "--force",
         "--role-file",
         role_file,
         "-v",


### PR DESCRIPTION
With this PR, if dependencies exist, we don't need to talk to `galaxy.ansible.com` every time by default.

Technically, it can be done via an explicit definition as below.

```yaml
dependency:
  name: galaxy
  options:
    requirements-file: requirements.yml
    force: false
```

## Compare

If we define `community.docker` as a dependency,

### Before

```log
Opened /Users/jackzhang/.ansible/galaxy_token
Collection 'community.docker:3.4.8' obtained from server default https://galaxy.ansible.com/api/
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/download/community-docker-3.4.8.tar.gz to /Users/jackzhang/.ansible/tmp/ansible-local-908270jolbbei/tmp8p2pq2qd/community-docker-3.4.8-ktwznndg
Installing 'community.docker:3.4.8' to '/Users/jackzhang/.ansible/collections/ansible_collections/community/docker'
community.docker:3.4.8 was installed successfully
INFO     Dependency completed successfully.
WARNING  Skipping, missing the requirements file.
```

### After

```log
Starting galaxy collection install process
Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`.
INFO     Dependency completed successfully.
WARNING  Skipping, missing the requirements file.
```